### PR TITLE
Adds support for HTTP timeouts

### DIFF
--- a/lib/zen_ex/http_client.ex
+++ b/lib/zen_ex/http_client.ex
@@ -55,4 +55,7 @@ defmodule ZenEx.HTTPClient do
   def _build_entity(%HTTPotion.Response{} = res, [{key, module}]) do
     res.body |> Poison.decode!(keys: :atoms, as: %{key => struct(module)}) |> Map.get(key)
   end
+  def _build_entity(%HTTPotion.ErrorResponse{message: error}, _) do
+    {:error, error}
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -43,7 +43,7 @@ defmodule ZenEx.Mixfile do
   defp deps do
     [
       {:earmark, "~> 1.2.1", only: :dev, runtime: false},
-      {:espec, "~> 1.3.4", only: :test},
+      {:espec, "~> 1.5.1", only: :test},
       {:ex_doc, "~> 0.14", only: :dev, runtime: false},
       {:httpotion, "~> 3.0.2"},
       {:poison, "~> 3.0"}

--- a/mix.lock
+++ b/mix.lock
@@ -1,17 +1,19 @@
-%{"certifi": {:hex, :certifi, "1.1.0", "c9b71a547016c2528a590ccfc28de786c7edb74aafa17446b84f54e04efc00ee", [:rebar3], [], "hexpm"},
+%{
+  "certifi": {:hex, :certifi, "1.1.0", "c9b71a547016c2528a590ccfc28de786c7edb74aafa17446b84f54e04efc00ee", [:rebar3], [], "hexpm"},
   "combine": {:hex, :combine, "0.9.6", "8d1034a127d4cbf6924c8a5010d3534d958085575fa4d9b878f200d79ac78335", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.1", "7ad3f203ab84d31832814483c834e006cf88949f061a4b50d7e783147572280f", [:mix], [], "hexpm"},
-  "espec": {:hex, :espec, "1.3.4", "8a67f6530dcc92a235af7767f6a323aa81c854ee069b28bc2340e54ab88468f9", [:mix], [{:meck, "0.8.4", [hex: :meck, repo: "hexpm", optional: false]}], "hexpm"},
+  "espec": {:hex, :espec, "1.5.1", "46c603c4adb4244b152ea53c4d5f4545ab1eb1de1556588ec908b8e4ba570188", [:mix], [{:meck, "0.8.9", [hex: :meck, repo: "hexpm", optional: false]}], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.15.1", "d5f9d588fd802152516fccfdb96d6073753f77314fcfee892b15b6724ca0d596", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "gettext": {:hex, :gettext, "0.13.1", "5e0daf4e7636d771c4c71ad5f3f53ba09a9ae5c250e1ab9c42ba9edccc476263", [:mix], [], "hexpm"},
   "hackney": {:hex, :hackney, "1.8.0", "8388a22f4e7eb04d171f2cf0285b217410f266d6c13a4c397a6c22ab823a486c", [:rebar3], [{:certifi, "1.1.0", [hex: :certifi, repo: "hexpm", optional: false]}, {:idna, "4.0.0", [hex: :idna, repo: "hexpm", optional: false]}, {:metrics, "1.0.1", [hex: :metrics, repo: "hexpm", optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, repo: "hexpm", optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, repo: "hexpm", optional: false]}], "hexpm"},
   "httpotion": {:hex, :httpotion, "3.0.2", "525b9bfeb592c914a61a8ee31fdde3871e1861dfe805f8ee5f711f9f11a93483", [:mix], [{:ibrowse, "~> 4.2", [hex: :ibrowse, repo: "hexpm", optional: false]}], "hexpm"},
   "ibrowse": {:hex, :ibrowse, "4.4.0", "2d923325efe0d2cb09b9c6a047b2835a5eda69d8a47ed6ff8bc03628b764e991", [:rebar3], [], "hexpm"},
   "idna": {:hex, :idna, "4.0.0", "10aaa9f79d0b12cf0def53038547855b91144f1bfcc0ec73494f38bb7b9c4961", [:rebar3], [], "hexpm"},
-  "meck": {:hex, :meck, "0.8.4", "59ca1cd971372aa223138efcf9b29475bde299e1953046a0c727184790ab1520", [:make, :rebar], [], "hexpm"},
+  "meck": {:hex, :meck, "0.8.9", "64c5c0bd8bcca3a180b44196265c8ed7594e16bcc845d0698ec6b4e577f48188", [:rebar3], [], "hexpm"},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm"},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], [], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], [], "hexpm"},
   "timex": {:hex, :timex, "3.1.13", "48b33162e3ec33e9a08fb5f98e3f3c19c3e328dded3156096c1969b77d33eef0", [:mix], [{:combine, "~> 0.7", [hex: :combine, repo: "hexpm", optional: false]}, {:gettext, "~> 0.10", [hex: :gettext, repo: "hexpm", optional: false]}, {:tzdata, "~> 0.1.8 or ~> 0.5", [hex: :tzdata, repo: "hexpm", optional: false]}], "hexpm"},
-  "tzdata": {:hex, :tzdata, "0.5.12", "1c17b68692c6ba5b6ab15db3d64cc8baa0f182043d5ae9d4b6d35d70af76f67b", [:mix], [{:hackney, "~> 1.0", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"}}
+  "tzdata": {:hex, :tzdata, "0.5.12", "1c17b68692c6ba5b6ab15db3d64cc8baa0f182043d5ae9d4b6d35d70af76f67b", [:mix], [{:hackney, "~> 1.0", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
+}

--- a/spec/zen_ex/core/models/ticket_spec.exs
+++ b/spec/zen_ex/core/models/ticket_spec.exs
@@ -27,6 +27,7 @@ defmodule ZenEx.Model.TicketSpec do
   let :response_job_status, do: %HTTPotion.Response{body: json_job_status()}
   let :response_204, do: %HTTPotion.Response{status_code: 204}
   let :response_404, do: %HTTPotion.Response{status_code: 404}
+  let :response_timeout, do: %HTTPotion.ErrorResponse{message: "req_timedout"}
 
   describe "list" do
     before do: allow HTTPotion |> to(accept :get, fn(_, _) -> response_tickets() end)
@@ -42,6 +43,11 @@ defmodule ZenEx.Model.TicketSpec do
   describe "create" do
     before do: allow HTTPotion |> to(accept :post, fn(_, _) -> response_ticket() end)
     it do: expect Model.Ticket.create(ticket()) |> to(be_struct Ticket)
+  end
+
+  describe "create timeout" do
+    before do: allow HTTPotion |> to(accept :post, fn(_, _) -> response_timeout() end)
+    it do: expect Model.Ticket.create(ticket()) |> to(eq {:error, "req_timedout"})
   end
 
   describe "update" do


### PR DESCRIPTION
Fixes below issue when there's an HTTP timeout

```
no function clause matching in ZenEx.HTTPClient._build_entity/2

http_client.ex 47 _build_entity(%HTTPotion.ErrorResponse{message: "req_timedout"}, [ticket: ZenEx.Entity.Ticket])
```