### PR TITLE
Support for User Search, and Support for Multiple Zendesk Configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,42 @@ ticket = ZenEx.Model.Ticket.create(%ZenEx.Entity.Ticket{subject: "My printer is 
 
 See also under ZenEx.Model.
 
+## Supporting multiple Zendesk configs
+You may need to interact with more than one instance of Zendesk. In order to facilitate that there is a small override
+that can be put into the Process dictionary that will tell it to look for config settings keyed against a class name.
+
+For example:
+
+config/config.exs
+```
+config :zen_ex,
+  subdomain: System.get_env("ZENDESK_SUBDOMAIN"),
+  user: System.get_env("ZENDESK_USER_EMAIL"),
+  api_token: System.get_env("ZENDESK_API_TOKEN")
+
+config :zen_ex, ZendeskAlt,
+  subdomain: System.get_env("ZENDESK_ALT_SUBDOMAIN"),
+  user: System.get_env("ZENDESK_ALT_USER_EMAIL"),
+  api_token: System.get_env("ZENDESK_ALT_API_TOKEN")
+```
+
+Then whenever you want to use the alternate config, before using anything in the `zen_ex` library make sure to
+add a line of code like the following:
+
+```
+Process.put(:zendesk_config_module, ZendeskAlt)
+```
+
+Anytime you use the zendesk library after that it will use the alternate config until you remove that process
+dictionary entry. It is good practice to put it back when you are done.
+
+```
+Process.put(:zendesk_config_module, nil)
+```
+
+If you do not add a `:zendesk_config_module` key to the Process dictionary then it will continue to use the
+default `zen_ex` config settings.
+
 ## Supported API
 
 ### [Core API](https://developer.zendesk.com/rest_api/docs/core/introduction)
@@ -72,6 +108,7 @@ See also under ZenEx.Model.
   - `update_many`
   - `create_or_update_many`
   - `destroy_many`
+  - `search`
 - Tickets
   - `list`
   - `show`

--- a/lib/zen_ex/core/models/user.ex
+++ b/lib/zen_ex/core/models/user.ex
@@ -156,4 +156,28 @@ defmodule ZenEx.Model.User do
   def destroy_many(ids) when is_list(ids) do
     HTTPClient.delete("/api/v2/users/destroy_many.json?ids=#{Enum.join(ids, ",")}", job_status: JobStatus)
   end
+
+  @doc """
+  Search for users specified by query.
+
+  ## Examples
+
+      iex> ZenEx.Model.User.search(%{email: "first.last@domain.com"})
+      %ZenEx.Collection{}
+
+      iex> ZenEx.Model.User.search("David"})
+      %ZenEx.Collection{}
+
+  """
+  @spec search(map()) :: %ZenEx.Collection{} | {:error, String.t()}
+  def search(opts) when is_map(opts) do
+    query = Map.keys(opts) |> Enum.map(fn key -> "#{key}:#{opts[key]}" end) |> Enum.join(" ")
+    search(query)
+  end
+
+  @spec search(String.t()) :: %ZenEx.Collection{} | {:error, String.t()}
+  def search(query) do
+    "/api/v2/users/search.json?query=#{query}"
+    |> HTTPClient.get(users: [User])
+  end
 end

--- a/lib/zen_ex/http_client.ex
+++ b/lib/zen_ex/http_client.ex
@@ -37,11 +37,11 @@ defmodule ZenEx.HTTPClient do
   end
 
   def build_url(endpoint) do
-    "https://#{Application.get_env(:zen_ex, :subdomain)}.zendesk.com#{endpoint}"
+    "https://#{get_env(:subdomain)}.zendesk.com#{endpoint}"
   end
 
   def basic_auth do
-    {"#{Application.get_env(:zen_ex, :user)}/token", "#{Application.get_env(:zen_ex, :api_token)}"}
+    {"#{get_env(:user)}/token", "#{get_env(:api_token)}"}
   end
 
   def _build_entity(%HTTPotion.Response{} = res, [{key, [module]}]) do
@@ -57,5 +57,10 @@ defmodule ZenEx.HTTPClient do
   end
   def _build_entity(%HTTPotion.ErrorResponse{message: error}, _) do
     {:error, error}
+  end
+
+  defp get_env(key) do
+    config_module = Process.get(:zendesk_config_module)
+    if config_module, do: Application.get_env(:zen_ex, config_module) |> Keyword.get(key), else: Application.get_env(:zen_ex, key)
   end
 end

--- a/lib/zen_ex/http_client.ex
+++ b/lib/zen_ex/http_client.ex
@@ -60,7 +60,9 @@ defmodule ZenEx.HTTPClient do
   end
 
   defp get_env(key) do
-    config_module = Process.get(:zendesk_config_module)
-    if config_module, do: Application.get_env(:zen_ex, config_module) |> Keyword.get(key), else: Application.get_env(:zen_ex, key)
-  end
+   case Process.get(:zendesk_config_module) do
+     nil -> Application.get_env(:zen_ex, key)
+     config_module -> Application.get_env(:zen_ex, config_module)[key]
+   end
+ end
 end

--- a/spec/zen_ex/core/models/user_spec.exs
+++ b/spec/zen_ex/core/models/user_spec.exs
@@ -75,4 +75,24 @@ defmodule ZenEx.Model.UserSpec do
     before do: allow HTTPotion |> to(accept :delete, fn(_, _) -> response_job_status() end)
     it do: expect Model.User.destroy_many(Enum.map(users(), &(&1.id))) |> to(be_struct JobStatus)
   end
+
+  describe "search" do
+    context "when argument is a map" do
+      before do: allow HTTPotion |> to(accept :get, fn(url, _) ->
+        it do: expect url |> to(eq "/api/v2/users/search.json?query=email:first.last@example.com")
+        response_users()
+      end)
+      it do: expect Model.User.search(%{email: "first.last@example.com"}) |> to(be_struct ZenEx.Collection)
+      it do: expect Model.User.search(%{email: "first.last@example.com"}).entities |> to(eq users())
+    end
+
+    context "when argument is a string" do
+      before do: allow HTTPotion |> to(accept :get, fn(url, _) ->
+        it do: expect url |> to(eq "/api/v2/users/search.json?query=my_string")
+        response_users()
+      end)
+      it do: expect Model.User.search("my_string") |> to(be_struct ZenEx.Collection)
+      it do: expect Model.User.search("my_string").entities |> to(eq users())
+    end
+  end
 end


### PR DESCRIPTION
## Description
This PR allows the `zen_ex` library to support multiple Zendesk configs within a single app using it. It also adds some support for the User.search method that is offered by the Zendesk API. 

In order to use the multiple configs, you want to have a set of core zen_ex config settings, as well as whatever auxiliary config settings you want to support keyed by a class name. For example: 

config/config.exs
```
config :zen_ex,
  subdomain: System.get_env("ZENDESK_SUBDOMAIN"),
  user: System.get_env("ZENDESK_USER_EMAIL"),
  api_token: System.get_env("ZENDESK_API_TOKEN")
config :zen_ex, ZendeskAlt,
  subdomain: System.get_env("ZENDESK_ALT_SUBDOMAIN"),
  user: System.get_env("ZENDESK_ALT_USER_EMAIL"),
  api_token: System.get_env("ZENDESK_ALT_API_TOKEN")
```

Then whenever you want to use the alternate config, before using anything in the `zen_ex` library make sure to add a line of code like the following:

```
Process.put(:zendesk_config_module, ZendeskAlt)
```

Anytime you use the zendesk library after that it will use the alternate config until you remove that process dictionary entry. It is good practice to put it back when you are done.

```
Process.put(:zendesk_config_module, nil)
```

If you do not add a `:zendesk_config_module` key to the Process dictionary then it will continue to use the default `zen_ex` config settings.