### PR TITLE
Loosen httpotion version requirement

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -45,7 +45,7 @@ defmodule ZenEx.Mixfile do
       {:earmark, "~> 1.4.3", only: :dev, runtime: false},
       {:espec, "~> 1.8.2", only: :test},
       {:ex_doc, "~> 0.22", only: :dev, runtime: false},
-      {:httpotion, "~> 3.0.2"},
+      {:httpotion, "~> 3.0"},
       {:poison, "~> 3.0"}
     ]
   end


### PR DESCRIPTION
There should be no breaking changes in these minor releases and loosening the requirement makes it easier to use in other projects.