### PR TITLE
Add ZenEx.Model.User.permanently_destroy

### DIFF
--- a/lib/zen_ex/core/models/user.ex
+++ b/lib/zen_ex/core/models/user.ex
@@ -94,6 +94,20 @@ defmodule ZenEx.Model.User do
   end
 
   @doc """
+  Permanently delete deactivated user specified by id.
+
+  ## Examples
+
+      iex> ZenEx.Model.User.permanently_destroy(1)
+      %ZenEx.Entity.User{id: 1, name: "xxx", active: false, ...}
+
+  """
+  @spec permanently_destroy(integer) :: %User{} | {:error, String.t()}
+  def permanently_destroy(id) when is_integer(id) do
+    HTTPClient.delete("/api/v2/deleted_users/#{id}.json", deleted_user: User)
+  end
+
+  @doc """
   Create multiple users.
 
   ## Examples

--- a/spec/zen_ex/core/models/user_spec.exs
+++ b/spec/zen_ex/core/models/user_spec.exs
@@ -17,6 +17,7 @@ defmodule ZenEx.Model.UserSpec do
   end
 
   let(:json_user, do: ~s({"user":{"id":223443,"name":"Johnny Agent"}}))
+  let(:json_deleted_user, do: ~s({"deleted_user":{"id":223443,"name":"Johnny Agent"}}))
   let(:user, do: struct(User, %{id: 223_443, name: "Johnny Agent"}))
 
   let :json_job_status do
@@ -32,6 +33,7 @@ defmodule ZenEx.Model.UserSpec do
   end
 
   let(:response_user, do: %Tesla.Env{body: json_user()})
+  let(:response_deleted_user, do: %Tesla.Env{body: json_deleted_user()})
   let(:response_users, do: %Tesla.Env{body: json_users()})
   let(:response_search_users, do: %Tesla.Env{body: json_search_users()})
   let(:response_job_status, do: %Tesla.Env{body: json_job_status()})
@@ -84,6 +86,17 @@ defmodule ZenEx.Model.UserSpec do
     )
 
     it(do: expect(Model.User.destroy(user().id) |> to(be_struct(User))))
+  end
+
+  describe "permanently_destroy" do
+    before(
+      do:
+        mock(fn %{method: :delete, url: _} ->
+          %Tesla.Env{status: 200, body: response_deleted_user()}
+        end)
+    )
+
+    it(do: expect(Model.User.permanently_destroy(user().id) |> to(be_struct(User))))
   end
 
   describe "create_many" do


### PR DESCRIPTION
In order to be GDPR compliant, one must delete a user permanently after
deleting the user.

This PR adds ZenEx.Model.User.permanently_destroy, which must be called
with the id of a user who has been previously destroyed.

See https://developer.zendesk.com/api-reference/ticketing/users/users/#permanently-delete-user.