### PR TITLE
Rework HTTPClient

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,6 @@
 # This file is responsible for configuring your application
 # and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 config :zen_ex,
   subdomain: "testdomain",

--- a/spec/zen_ex/core/models/dynamic_content/variant_spec.exs
+++ b/spec/zen_ex/core/models/dynamic_content/variant_spec.exs
@@ -35,8 +35,7 @@ defmodule ZenEx.Model.DynamicContent.VariantSpec do
 
   describe "list" do
     before(
-      do:
-        mock(fn %{method: :get, url: _} -> %Tesla.Env{status: 200, body: json_variants()} end)
+      do: mock(fn %{method: :get, url: _} -> %Tesla.Env{status: 200, body: json_variants()} end)
     )
 
     it(
@@ -58,8 +57,7 @@ defmodule ZenEx.Model.DynamicContent.VariantSpec do
 
   describe "show" do
     before(
-      do:
-        mock(fn %{method: :get, url: _} -> %Tesla.Env{status: 200, body: json_variant()} end)
+      do: mock(fn %{method: :get, url: _} -> %Tesla.Env{status: 200, body: json_variant()} end)
     )
 
     it(
@@ -73,8 +71,7 @@ defmodule ZenEx.Model.DynamicContent.VariantSpec do
 
   describe "create" do
     before(
-      do:
-        mock(fn %{method: :post, url: _} -> %Tesla.Env{status: 200, body: json_variant()} end)
+      do: mock(fn %{method: :post, url: _} -> %Tesla.Env{status: 200, body: json_variant()} end)
     )
 
     it(
@@ -105,8 +102,7 @@ defmodule ZenEx.Model.DynamicContent.VariantSpec do
 
   describe "update" do
     before(
-      do:
-        mock(fn %{method: :put, url: _} -> %Tesla.Env{status: 200, body: json_variant()} end)
+      do: mock(fn %{method: :put, url: _} -> %Tesla.Env{status: 200, body: json_variant()} end)
     )
 
     it(
@@ -137,10 +133,7 @@ defmodule ZenEx.Model.DynamicContent.VariantSpec do
 
   describe "destroy" do
     context "response status: 204" do
-      before(
-        do:
-          mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 204} end)
-      )
+      before(do: mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 204} end))
 
       it(
         do:
@@ -152,10 +145,7 @@ defmodule ZenEx.Model.DynamicContent.VariantSpec do
     end
 
     context "response status: 404" do
-      before(
-        do:
-          mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 404} end)
-      )
+      before(do: mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 404} end))
 
       it(
         do:

--- a/spec/zen_ex/core/models/dynamic_content/variant_spec.exs
+++ b/spec/zen_ex/core/models/dynamic_content/variant_spec.exs
@@ -33,16 +33,10 @@ defmodule ZenEx.Model.DynamicContent.VariantSpec do
     struct(DynamicContent, %{id: 112_233, name: "mail-address", default_locale_id: 1})
   end
 
-  let(:response_variant, do: %Tesla.Env{body: json_variant()})
-  let(:response_variants, do: %Tesla.Env{body: json_variants()})
-  let(:response_job_status, do: %Tesla.Env{body: json_job_status()})
-  let(:response_204, do: %Tesla.Env{status: 204})
-  let(:response_404, do: %Tesla.Env{status: 404})
-
   describe "list" do
     before(
       do:
-        mock(fn %{method: :get, url: _} -> %Tesla.Env{status: 200, body: response_variants()} end)
+        mock(fn %{method: :get, url: _} -> %Tesla.Env{status: 200, body: json_variants()} end)
     )
 
     it(
@@ -65,7 +59,7 @@ defmodule ZenEx.Model.DynamicContent.VariantSpec do
   describe "show" do
     before(
       do:
-        mock(fn %{method: :get, url: _} -> %Tesla.Env{status: 200, body: response_variant()} end)
+        mock(fn %{method: :get, url: _} -> %Tesla.Env{status: 200, body: json_variant()} end)
     )
 
     it(
@@ -80,7 +74,7 @@ defmodule ZenEx.Model.DynamicContent.VariantSpec do
   describe "create" do
     before(
       do:
-        mock(fn %{method: :post, url: _} -> %Tesla.Env{status: 200, body: response_variant()} end)
+        mock(fn %{method: :post, url: _} -> %Tesla.Env{status: 200, body: json_variant()} end)
     )
 
     it(
@@ -96,7 +90,7 @@ defmodule ZenEx.Model.DynamicContent.VariantSpec do
     before(
       do:
         mock(fn %{method: :post, url: _} ->
-          %Tesla.Env{status: 200, body: response_job_status()}
+          %Tesla.Env{status: 200, body: json_job_status()}
         end)
     )
 
@@ -112,7 +106,7 @@ defmodule ZenEx.Model.DynamicContent.VariantSpec do
   describe "update" do
     before(
       do:
-        mock(fn %{method: :put, url: _} -> %Tesla.Env{status: 200, body: response_variant()} end)
+        mock(fn %{method: :put, url: _} -> %Tesla.Env{status: 200, body: json_variant()} end)
     )
 
     it(
@@ -128,7 +122,7 @@ defmodule ZenEx.Model.DynamicContent.VariantSpec do
     before(
       do:
         mock(fn %{method: :put, url: _} ->
-          %Tesla.Env{status: 200, body: response_job_status()}
+          %Tesla.Env{status: 200, body: json_job_status()}
         end)
     )
 
@@ -145,7 +139,7 @@ defmodule ZenEx.Model.DynamicContent.VariantSpec do
     context "response status: 204" do
       before(
         do:
-          mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 200, body: response_204()} end)
+          mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 204} end)
       )
 
       it(
@@ -160,7 +154,7 @@ defmodule ZenEx.Model.DynamicContent.VariantSpec do
     context "response status: 404" do
       before(
         do:
-          mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 200, body: response_404()} end)
+          mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 404} end)
       )
 
       it(

--- a/spec/zen_ex/core/models/dynamic_content_spec.exs
+++ b/spec/zen_ex/core/models/dynamic_content_spec.exs
@@ -94,19 +94,13 @@ defmodule ZenEx.Model.DynamicContentSpec do
 
   describe "destroy" do
     context "response status: 204" do
-      before(
-        do:
-          mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 204} end)
-      )
+      before(do: mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 204} end))
 
       it(do: expect(Model.DynamicContent.destroy(dynamic_content().id) |> to(eq(:ok))))
     end
 
     context "response status: 404" do
-      before(
-        do:
-          mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 404} end)
-      )
+      before(do: mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 404} end))
 
       it(do: expect(Model.DynamicContent.destroy(dynamic_content().id) |> to(eq(:error))))
     end

--- a/spec/zen_ex/core/models/dynamic_content_spec.exs
+++ b/spec/zen_ex/core/models/dynamic_content_spec.exs
@@ -43,16 +43,11 @@ defmodule ZenEx.Model.DynamicContentSpec do
     })
   end
 
-  let(:response_dynamic_content, do: %Tesla.Env{body: json_dynamic_content()})
-  let(:response_dynamic_contents, do: %Tesla.Env{body: json_dynamic_contents()})
-  let(:response_204, do: %Tesla.Env{status: 204})
-  let(:response_404, do: %Tesla.Env{status: 404})
-
   describe "list" do
     before(
       do:
         mock(fn %{method: :get, url: _} ->
-          %Tesla.Env{status: 200, body: response_dynamic_contents()}
+          %Tesla.Env{status: 200, body: json_dynamic_contents()}
         end)
     )
 
@@ -64,7 +59,7 @@ defmodule ZenEx.Model.DynamicContentSpec do
     before(
       do:
         mock(fn %{method: :get, url: _} ->
-          %Tesla.Env{status: 200, body: response_dynamic_content()}
+          %Tesla.Env{status: 200, body: json_dynamic_content()}
         end)
     )
 
@@ -75,7 +70,7 @@ defmodule ZenEx.Model.DynamicContentSpec do
     before(
       do:
         mock(fn %{method: :post, url: _} ->
-          %Tesla.Env{status: 200, body: response_dynamic_content()}
+          %Tesla.Env{status: 200, body: json_dynamic_content()}
         end)
     )
 
@@ -88,7 +83,7 @@ defmodule ZenEx.Model.DynamicContentSpec do
     before(
       do:
         mock(fn %{method: :put, url: _} ->
-          %Tesla.Env{status: 200, body: response_dynamic_content()}
+          %Tesla.Env{status: 200, body: json_dynamic_content()}
         end)
     )
 
@@ -101,7 +96,7 @@ defmodule ZenEx.Model.DynamicContentSpec do
     context "response status: 204" do
       before(
         do:
-          mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 200, body: response_204()} end)
+          mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 204} end)
       )
 
       it(do: expect(Model.DynamicContent.destroy(dynamic_content().id) |> to(eq(:ok))))
@@ -110,7 +105,7 @@ defmodule ZenEx.Model.DynamicContentSpec do
     context "response status: 404" do
       before(
         do:
-          mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 200, body: response_404()} end)
+          mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 404} end)
       )
 
       it(do: expect(Model.DynamicContent.destroy(dynamic_content().id) |> to(eq(:error))))

--- a/spec/zen_ex/core/models/job_status_spec.exs
+++ b/spec/zen_ex/core/models/job_status_spec.exs
@@ -42,14 +42,11 @@ defmodule ZenEx.Model.JobStatusSpec do
     })
   end
 
-  let(:response_job_status, do: %Tesla.Env{body: json_job_status()})
-  let(:response_job_statuses, do: %Tesla.Env{body: json_job_statuses()})
-
   describe "list" do
     before(
       do:
         mock(fn %{method: :get, url: _} ->
-          %Tesla.Env{status: 200, body: response_job_statuses()}
+          %Tesla.Env{status: 200, body: json_job_statuses()}
         end)
     )
 
@@ -61,7 +58,7 @@ defmodule ZenEx.Model.JobStatusSpec do
     before(
       do:
         mock(fn %{method: :get, url: _} ->
-          %Tesla.Env{status: 200, body: response_job_status()}
+          %Tesla.Env{status: 200, body: json_job_status()}
         end)
     )
 
@@ -72,7 +69,7 @@ defmodule ZenEx.Model.JobStatusSpec do
     before(
       do:
         mock(fn %{method: :get, url: _} ->
-          %Tesla.Env{status: 200, body: response_job_statuses()}
+          %Tesla.Env{status: 200, body: json_job_statuses()}
         end)
     )
 

--- a/spec/zen_ex/core/models/locale_spec.exs
+++ b/spec/zen_ex/core/models/locale_spec.exs
@@ -8,11 +8,9 @@ defmodule ZenEx.Model.LocaleSpec do
   let(:json_locale, do: ~s({"locale":{"id":8,"locale":"de","name":"Deutsch"}}))
   let(:locale, do: struct(Locale, %{id: 8, locale: "de", name: "Deutsch"}))
 
-  let(:response_locale, do: %Tesla.Env{body: json_locale()})
-
   describe "show" do
     before(
-      do: mock(fn %{method: :get, url: _} -> %Tesla.Env{status: 200, body: response_locale()} end)
+      do: mock(fn %{method: :get, url: _} -> %Tesla.Env{status: 200, body: json_locale()} end)
     )
 
     it(do: expect(Model.Locale.show(locale().id) |> to(eq(locale()))))

--- a/spec/zen_ex/core/models/ticket_spec.exs
+++ b/spec/zen_ex/core/models/ticket_spec.exs
@@ -33,8 +33,7 @@ defmodule ZenEx.Model.TicketSpec do
 
   describe "list" do
     before(
-      do:
-        mock(fn %{method: :get, url: _} -> %Tesla.Env{status: 200, body: json_tickets()} end)
+      do: mock(fn %{method: :get, url: _} -> %Tesla.Env{status: 200, body: json_tickets()} end)
     )
 
     it(do: expect(Model.Ticket.list() |> to(be_struct(ZenEx.Collection))))
@@ -51,8 +50,7 @@ defmodule ZenEx.Model.TicketSpec do
 
   describe "create" do
     before(
-      do:
-        mock(fn %{method: :post, url: _} -> %Tesla.Env{status: 200, body: json_ticket()} end)
+      do: mock(fn %{method: :post, url: _} -> %Tesla.Env{status: 200, body: json_ticket()} end)
     )
 
     it(do: expect(Model.Ticket.create(ticket()) |> to(be_struct(Ticket))))
@@ -68,19 +66,13 @@ defmodule ZenEx.Model.TicketSpec do
 
   describe "destroy" do
     context "response status: 204" do
-      before(
-        do:
-          mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 204} end)
-      )
+      before(do: mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 204} end))
 
       it(do: expect(Model.Ticket.destroy(ticket().id) |> to(eq(:ok))))
     end
 
     context "response status: 404" do
-      before(
-        do:
-          mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 404} end)
-      )
+      before(do: mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 404} end))
 
       it(do: expect(Model.Ticket.destroy(ticket().id) |> to(eq(:error))))
     end

--- a/spec/zen_ex/core/models/ticket_spec.exs
+++ b/spec/zen_ex/core/models/ticket_spec.exs
@@ -31,17 +31,10 @@ defmodule ZenEx.Model.TicketSpec do
     ~s({"count":2,"results":[{"id":35436,"subject":"Help I need somebody!"},{"id":20057623,"subject":"Not just anybody!"}]})
   end
 
-  let(:response_ticket, do: %Tesla.Env{body: json_ticket()})
-  let(:response_tickets, do: %Tesla.Env{body: json_tickets()})
-  let(:response_search_tickets, do: %Tesla.Env{body: json_search_tickets()})
-  let(:response_job_status, do: %Tesla.Env{body: json_job_status()})
-  let(:response_204, do: %Tesla.Env{status: 204})
-  let(:response_404, do: %Tesla.Env{status: 404})
-
   describe "list" do
     before(
       do:
-        mock(fn %{method: :get, url: _} -> %Tesla.Env{status: 200, body: response_tickets()} end)
+        mock(fn %{method: :get, url: _} -> %Tesla.Env{status: 200, body: json_tickets()} end)
     )
 
     it(do: expect(Model.Ticket.list() |> to(be_struct(ZenEx.Collection))))
@@ -50,7 +43,7 @@ defmodule ZenEx.Model.TicketSpec do
 
   describe "show" do
     before(
-      do: mock(fn %{method: :get, url: _} -> %Tesla.Env{status: 200, body: response_ticket()} end)
+      do: mock(fn %{method: :get, url: _} -> %Tesla.Env{status: 200, body: json_ticket()} end)
     )
 
     it(do: expect(Model.Ticket.show(ticket().id) |> to(eq(ticket()))))
@@ -59,7 +52,7 @@ defmodule ZenEx.Model.TicketSpec do
   describe "create" do
     before(
       do:
-        mock(fn %{method: :post, url: _} -> %Tesla.Env{status: 200, body: response_ticket()} end)
+        mock(fn %{method: :post, url: _} -> %Tesla.Env{status: 200, body: json_ticket()} end)
     )
 
     it(do: expect(Model.Ticket.create(ticket()) |> to(be_struct(Ticket))))
@@ -67,7 +60,7 @@ defmodule ZenEx.Model.TicketSpec do
 
   describe "update" do
     before(
-      do: mock(fn %{method: :put, url: _} -> %Tesla.Env{status: 200, body: response_ticket()} end)
+      do: mock(fn %{method: :put, url: _} -> %Tesla.Env{status: 200, body: json_ticket()} end)
     )
 
     it(do: expect(Model.Ticket.update(ticket()) |> to(be_struct(Ticket))))
@@ -77,7 +70,7 @@ defmodule ZenEx.Model.TicketSpec do
     context "response status: 204" do
       before(
         do:
-          mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 200, body: response_204()} end)
+          mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 204} end)
       )
 
       it(do: expect(Model.Ticket.destroy(ticket().id) |> to(eq(:ok))))
@@ -86,7 +79,7 @@ defmodule ZenEx.Model.TicketSpec do
     context "response status: 404" do
       before(
         do:
-          mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 200, body: response_404()} end)
+          mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 404} end)
       )
 
       it(do: expect(Model.Ticket.destroy(ticket().id) |> to(eq(:error))))
@@ -97,7 +90,7 @@ defmodule ZenEx.Model.TicketSpec do
     before(
       do:
         mock(fn %{method: :post, url: _} ->
-          %Tesla.Env{status: 200, body: response_job_status()}
+          %Tesla.Env{status: 200, body: json_job_status()}
         end)
     )
 
@@ -108,7 +101,7 @@ defmodule ZenEx.Model.TicketSpec do
     before(
       do:
         mock(fn %{method: :put, url: _} ->
-          %Tesla.Env{status: 200, body: response_job_status()}
+          %Tesla.Env{status: 200, body: json_job_status()}
         end)
     )
 
@@ -119,7 +112,7 @@ defmodule ZenEx.Model.TicketSpec do
     before(
       do:
         mock(fn %{method: :delete, url: _} ->
-          %Tesla.Env{status: 200, body: response_job_status()}
+          %Tesla.Env{status: 200, body: json_job_status()}
         end)
     )
 
@@ -136,7 +129,7 @@ defmodule ZenEx.Model.TicketSpec do
     before(
       do:
         mock(fn %{method: :get, url: _} ->
-          %Tesla.Env{status: 200, body: response_search_tickets()}
+          %Tesla.Env{status: 200, body: json_search_tickets()}
         end)
     )
 

--- a/spec/zen_ex/core/models/user_spec.exs
+++ b/spec/zen_ex/core/models/user_spec.exs
@@ -42,9 +42,7 @@ defmodule ZenEx.Model.UserSpec do
   end
 
   describe "show" do
-    before(
-      do: mock(fn %{method: :get, url: _} -> %Tesla.Env{status: 200, body: json_user()} end)
-    )
+    before(do: mock(fn %{method: :get, url: _} -> %Tesla.Env{status: 200, body: json_user()} end))
 
     it(do: expect(Model.User.show(user().id) |> to(eq(user()))))
   end
@@ -58,9 +56,7 @@ defmodule ZenEx.Model.UserSpec do
   end
 
   describe "update" do
-    before(
-      do: mock(fn %{method: :put, url: _} -> %Tesla.Env{status: 200, body: json_user()} end)
-    )
+    before(do: mock(fn %{method: :put, url: _} -> %Tesla.Env{status: 200, body: json_user()} end))
 
     it(do: expect(Model.User.update(user()) |> to(be_struct(User))))
   end
@@ -75,8 +71,7 @@ defmodule ZenEx.Model.UserSpec do
 
   describe "destroy" do
     before(
-      do:
-        mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 200, body: json_user()} end)
+      do: mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 200, body: json_user()} end)
     )
 
     it(do: expect(Model.User.destroy(user().id) |> to(be_struct(User))))

--- a/spec/zen_ex/core/models/user_spec.exs
+++ b/spec/zen_ex/core/models/user_spec.exs
@@ -32,15 +32,9 @@ defmodule ZenEx.Model.UserSpec do
     ~s({"count":2,"users":[{"id":223443,"name":"Johnny Agent"},{"id":8678530,"name":"James A. Rosen"}]})
   end
 
-  let(:response_user, do: %Tesla.Env{body: json_user()})
-  let(:response_deleted_user, do: %Tesla.Env{body: json_deleted_user()})
-  let(:response_users, do: %Tesla.Env{body: json_users()})
-  let(:response_search_users, do: %Tesla.Env{body: json_search_users()})
-  let(:response_job_status, do: %Tesla.Env{body: json_job_status()})
-
   describe "list" do
     before(
-      do: mock(fn %{method: :get, url: _} -> %Tesla.Env{status: 200, body: response_users()} end)
+      do: mock(fn %{method: :get, url: _} -> %Tesla.Env{status: 200, body: json_users()} end)
     )
 
     it(do: expect(Model.User.list() |> to(be_struct(ZenEx.Collection))))
@@ -49,7 +43,7 @@ defmodule ZenEx.Model.UserSpec do
 
   describe "show" do
     before(
-      do: mock(fn %{method: :get, url: _} -> %Tesla.Env{status: 200, body: response_user()} end)
+      do: mock(fn %{method: :get, url: _} -> %Tesla.Env{status: 200, body: json_user()} end)
     )
 
     it(do: expect(Model.User.show(user().id) |> to(eq(user()))))
@@ -57,7 +51,7 @@ defmodule ZenEx.Model.UserSpec do
 
   describe "create" do
     before(
-      do: mock(fn %{method: :post, url: _} -> %Tesla.Env{status: 200, body: response_user()} end)
+      do: mock(fn %{method: :post, url: _} -> %Tesla.Env{status: 200, body: json_user()} end)
     )
 
     it(do: expect(Model.User.create(user()) |> to(be_struct(User))))
@@ -65,7 +59,7 @@ defmodule ZenEx.Model.UserSpec do
 
   describe "update" do
     before(
-      do: mock(fn %{method: :put, url: _} -> %Tesla.Env{status: 200, body: response_user()} end)
+      do: mock(fn %{method: :put, url: _} -> %Tesla.Env{status: 200, body: json_user()} end)
     )
 
     it(do: expect(Model.User.update(user()) |> to(be_struct(User))))
@@ -73,7 +67,7 @@ defmodule ZenEx.Model.UserSpec do
 
   describe "create_or_update" do
     before(
-      do: mock(fn %{method: :post, url: _} -> %Tesla.Env{status: 200, body: response_user()} end)
+      do: mock(fn %{method: :post, url: _} -> %Tesla.Env{status: 200, body: json_user()} end)
     )
 
     it(do: expect(Model.User.create_or_update(user()) |> to(be_struct(User))))
@@ -82,7 +76,7 @@ defmodule ZenEx.Model.UserSpec do
   describe "destroy" do
     before(
       do:
-        mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 200, body: response_user()} end)
+        mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 200, body: json_user()} end)
     )
 
     it(do: expect(Model.User.destroy(user().id) |> to(be_struct(User))))
@@ -92,7 +86,7 @@ defmodule ZenEx.Model.UserSpec do
     before(
       do:
         mock(fn %{method: :delete, url: _} ->
-          %Tesla.Env{status: 200, body: response_deleted_user()}
+          %Tesla.Env{status: 200, body: json_deleted_user()}
         end)
     )
 
@@ -103,7 +97,7 @@ defmodule ZenEx.Model.UserSpec do
     before(
       do:
         mock(fn %{method: :post, url: _} ->
-          %Tesla.Env{status: 200, body: response_job_status()}
+          %Tesla.Env{status: 200, body: json_job_status()}
         end)
     )
 
@@ -114,7 +108,7 @@ defmodule ZenEx.Model.UserSpec do
     before(
       do:
         mock(fn %{method: :put, url: _} ->
-          %Tesla.Env{status: 200, body: response_job_status()}
+          %Tesla.Env{status: 200, body: json_job_status()}
         end)
     )
 
@@ -125,7 +119,7 @@ defmodule ZenEx.Model.UserSpec do
     before(
       do:
         mock(fn %{method: :post, url: _} ->
-          %Tesla.Env{status: 200, body: response_job_status()}
+          %Tesla.Env{status: 200, body: json_job_status()}
         end)
     )
 
@@ -136,7 +130,7 @@ defmodule ZenEx.Model.UserSpec do
     before(
       do:
         mock(fn %{method: :delete, url: _} ->
-          %Tesla.Env{status: 200, body: response_job_status()}
+          %Tesla.Env{status: 200, body: json_job_status()}
         end)
     )
 
@@ -149,7 +143,7 @@ defmodule ZenEx.Model.UserSpec do
     before(
       do:
         mock(fn %{method: :get, url: _} ->
-          %Tesla.Env{status: 200, body: response_search_users()}
+          %Tesla.Env{status: 200, body: json_search_users()}
         end)
     )
 

--- a/spec/zen_ex/help_center/models/article_spec.exs
+++ b/spec/zen_ex/help_center/models/article_spec.exs
@@ -51,8 +51,7 @@ defmodule ZenEx.HelpCenter.Model.ArticleSpec do
 
   describe "list" do
     before(
-      do:
-        mock(fn %{method: :get, url: _} -> %Tesla.Env{status: 200, body: json_articles()} end)
+      do: mock(fn %{method: :get, url: _} -> %Tesla.Env{status: 200, body: json_articles()} end)
     )
 
     it(do: expect(Model.Article.list("en-us") |> to(be_struct(ZenEx.Collection))))
@@ -62,8 +61,7 @@ defmodule ZenEx.HelpCenter.Model.ArticleSpec do
 
   describe "show" do
     before(
-      do:
-        mock(fn %{method: :get, url: _} -> %Tesla.Env{status: 200, body: json_article()} end)
+      do: mock(fn %{method: :get, url: _} -> %Tesla.Env{status: 200, body: json_article()} end)
     )
 
     it(do: expect(Model.Article.show("en-us", article().id) |> to(eq(article()))))
@@ -71,8 +69,7 @@ defmodule ZenEx.HelpCenter.Model.ArticleSpec do
 
   describe "create" do
     before(
-      do:
-        mock(fn %{method: :post, url: _} -> %Tesla.Env{status: 200, body: json_article()} end)
+      do: mock(fn %{method: :post, url: _} -> %Tesla.Env{status: 200, body: json_article()} end)
     )
 
     it(do: expect(Model.Article.create(article()) |> to(be_struct(Article))))
@@ -80,8 +77,7 @@ defmodule ZenEx.HelpCenter.Model.ArticleSpec do
 
   describe "update" do
     before(
-      do:
-        mock(fn %{method: :put, url: _} -> %Tesla.Env{status: 200, body: json_article()} end)
+      do: mock(fn %{method: :put, url: _} -> %Tesla.Env{status: 200, body: json_article()} end)
     )
 
     it(do: expect(Model.Article.update(article()) |> to(be_struct(Article))))
@@ -89,19 +85,13 @@ defmodule ZenEx.HelpCenter.Model.ArticleSpec do
 
   describe "destroy" do
     context "response status: 204" do
-      before(
-        do:
-          mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 204} end)
-      )
+      before(do: mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 204} end))
 
       it(do: expect(Model.Article.destroy(article().id) |> to(eq(:ok))))
     end
 
     context "response status: 404" do
-      before(
-        do:
-          mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 404} end)
-      )
+      before(do: mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 404} end))
 
       it(do: expect(Model.Article.destroy(article().id) |> to(eq(:error))))
     end
@@ -109,8 +99,7 @@ defmodule ZenEx.HelpCenter.Model.ArticleSpec do
 
   describe "search" do
     before(
-      do:
-        mock(fn %{method: :get, url: _} -> %Tesla.Env{status: 200, body: json_results()} end)
+      do: mock(fn %{method: :get, url: _} -> %Tesla.Env{status: 200, body: json_results()} end)
     )
 
     it(

--- a/spec/zen_ex/help_center/models/article_spec.exs
+++ b/spec/zen_ex/help_center/models/article_spec.exs
@@ -49,16 +49,10 @@ defmodule ZenEx.HelpCenter.Model.ArticleSpec do
     ~s({"results":[{"id":35436,"name":"Help I need somebody!","locale":"en-us","section_id":112233},{"id":20057623,"name":"Not just anybody!","locale":"en-us","section_id":112233}]})
   end
 
-  let(:response_article, do: %Tesla.Env{body: json_article()})
-  let(:response_articles, do: %Tesla.Env{body: json_articles()})
-  let(:response_results, do: %Tesla.Env{body: json_results()})
-  let(:response_204, do: %Tesla.Env{status: 204})
-  let(:response_404, do: %Tesla.Env{status: 404})
-
   describe "list" do
     before(
       do:
-        mock(fn %{method: :get, url: _} -> %Tesla.Env{status: 200, body: response_articles()} end)
+        mock(fn %{method: :get, url: _} -> %Tesla.Env{status: 200, body: json_articles()} end)
     )
 
     it(do: expect(Model.Article.list("en-us") |> to(be_struct(ZenEx.Collection))))
@@ -69,7 +63,7 @@ defmodule ZenEx.HelpCenter.Model.ArticleSpec do
   describe "show" do
     before(
       do:
-        mock(fn %{method: :get, url: _} -> %Tesla.Env{status: 200, body: response_article()} end)
+        mock(fn %{method: :get, url: _} -> %Tesla.Env{status: 200, body: json_article()} end)
     )
 
     it(do: expect(Model.Article.show("en-us", article().id) |> to(eq(article()))))
@@ -78,7 +72,7 @@ defmodule ZenEx.HelpCenter.Model.ArticleSpec do
   describe "create" do
     before(
       do:
-        mock(fn %{method: :post, url: _} -> %Tesla.Env{status: 200, body: response_article()} end)
+        mock(fn %{method: :post, url: _} -> %Tesla.Env{status: 200, body: json_article()} end)
     )
 
     it(do: expect(Model.Article.create(article()) |> to(be_struct(Article))))
@@ -87,7 +81,7 @@ defmodule ZenEx.HelpCenter.Model.ArticleSpec do
   describe "update" do
     before(
       do:
-        mock(fn %{method: :put, url: _} -> %Tesla.Env{status: 200, body: response_article()} end)
+        mock(fn %{method: :put, url: _} -> %Tesla.Env{status: 200, body: json_article()} end)
     )
 
     it(do: expect(Model.Article.update(article()) |> to(be_struct(Article))))
@@ -97,7 +91,7 @@ defmodule ZenEx.HelpCenter.Model.ArticleSpec do
     context "response status: 204" do
       before(
         do:
-          mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 200, body: response_204()} end)
+          mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 204} end)
       )
 
       it(do: expect(Model.Article.destroy(article().id) |> to(eq(:ok))))
@@ -106,7 +100,7 @@ defmodule ZenEx.HelpCenter.Model.ArticleSpec do
     context "response status: 404" do
       before(
         do:
-          mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 200, body: response_404()} end)
+          mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 404} end)
       )
 
       it(do: expect(Model.Article.destroy(article().id) |> to(eq(:error))))
@@ -116,7 +110,7 @@ defmodule ZenEx.HelpCenter.Model.ArticleSpec do
   describe "search" do
     before(
       do:
-        mock(fn %{method: :get, url: _} -> %Tesla.Env{status: 200, body: response_results()} end)
+        mock(fn %{method: :get, url: _} -> %Tesla.Env{status: 200, body: json_results()} end)
     )
 
     it(

--- a/spec/zen_ex/help_center/models/category_spec.exs
+++ b/spec/zen_ex/help_center/models/category_spec.exs
@@ -38,8 +38,7 @@ defmodule ZenEx.HelpCenter.Model.CategorySpec do
 
   describe "show" do
     before(
-      do:
-        mock(fn %{method: :get, url: _} -> %Tesla.Env{status: 200, body: json_category()} end)
+      do: mock(fn %{method: :get, url: _} -> %Tesla.Env{status: 200, body: json_category()} end)
     )
 
     it(do: expect(Model.Category.show("en-us", category().id) |> to(eq(category()))))
@@ -47,8 +46,7 @@ defmodule ZenEx.HelpCenter.Model.CategorySpec do
 
   describe "create" do
     before(
-      do:
-        mock(fn %{method: :post, url: _} -> %Tesla.Env{status: 200, body: json_category()} end)
+      do: mock(fn %{method: :post, url: _} -> %Tesla.Env{status: 200, body: json_category()} end)
     )
 
     it(do: expect(Model.Category.create(category()) |> to(be_struct(Category))))
@@ -56,8 +54,7 @@ defmodule ZenEx.HelpCenter.Model.CategorySpec do
 
   describe "update" do
     before(
-      do:
-        mock(fn %{method: :put, url: _} -> %Tesla.Env{status: 200, body: json_category()} end)
+      do: mock(fn %{method: :put, url: _} -> %Tesla.Env{status: 200, body: json_category()} end)
     )
 
     it(do: expect(Model.Category.update(category()) |> to(be_struct(Category))))
@@ -65,19 +62,13 @@ defmodule ZenEx.HelpCenter.Model.CategorySpec do
 
   describe "destroy" do
     context "response status: 204" do
-      before(
-        do:
-          mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 204} end)
-      )
+      before(do: mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 204} end))
 
       it(do: expect(Model.Category.destroy(category().id) |> to(eq(:ok))))
     end
 
     context "response status: 404" do
-      before(
-        do:
-          mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 404} end)
-      )
+      before(do: mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 404} end))
 
       it(do: expect(Model.Category.destroy(category().id) |> to(eq(:error))))
     end

--- a/spec/zen_ex/help_center/models/category_spec.exs
+++ b/spec/zen_ex/help_center/models/category_spec.exs
@@ -24,16 +24,11 @@ defmodule ZenEx.HelpCenter.Model.CategorySpec do
     do: struct(Category, %{id: 35436, name: "My printer is on fire!", locale: "en-us"})
   )
 
-  let(:response_category, do: %Tesla.Env{body: json_category()})
-  let(:response_categories, do: %Tesla.Env{body: json_categories()})
-  let(:response_204, do: %Tesla.Env{status: 204})
-  let(:response_404, do: %Tesla.Env{status: 404})
-
   describe "list" do
     before(
       do:
         mock(fn %{method: :get, url: _} ->
-          %Tesla.Env{status: 200, body: response_categories()}
+          %Tesla.Env{status: 200, body: json_categories()}
         end)
     )
 
@@ -44,7 +39,7 @@ defmodule ZenEx.HelpCenter.Model.CategorySpec do
   describe "show" do
     before(
       do:
-        mock(fn %{method: :get, url: _} -> %Tesla.Env{status: 200, body: response_category()} end)
+        mock(fn %{method: :get, url: _} -> %Tesla.Env{status: 200, body: json_category()} end)
     )
 
     it(do: expect(Model.Category.show("en-us", category().id) |> to(eq(category()))))
@@ -53,7 +48,7 @@ defmodule ZenEx.HelpCenter.Model.CategorySpec do
   describe "create" do
     before(
       do:
-        mock(fn %{method: :post, url: _} -> %Tesla.Env{status: 200, body: response_category()} end)
+        mock(fn %{method: :post, url: _} -> %Tesla.Env{status: 200, body: json_category()} end)
     )
 
     it(do: expect(Model.Category.create(category()) |> to(be_struct(Category))))
@@ -62,7 +57,7 @@ defmodule ZenEx.HelpCenter.Model.CategorySpec do
   describe "update" do
     before(
       do:
-        mock(fn %{method: :put, url: _} -> %Tesla.Env{status: 200, body: response_category()} end)
+        mock(fn %{method: :put, url: _} -> %Tesla.Env{status: 200, body: json_category()} end)
     )
 
     it(do: expect(Model.Category.update(category()) |> to(be_struct(Category))))
@@ -72,7 +67,7 @@ defmodule ZenEx.HelpCenter.Model.CategorySpec do
     context "response status: 204" do
       before(
         do:
-          mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 200, body: response_204()} end)
+          mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 204} end)
       )
 
       it(do: expect(Model.Category.destroy(category().id) |> to(eq(:ok))))
@@ -81,7 +76,7 @@ defmodule ZenEx.HelpCenter.Model.CategorySpec do
     context "response status: 404" do
       before(
         do:
-          mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 200, body: response_404()} end)
+          mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 404} end)
       )
 
       it(do: expect(Model.Category.destroy(category().id) |> to(eq(:error))))

--- a/spec/zen_ex/help_center/models/section_spec.exs
+++ b/spec/zen_ex/help_center/models/section_spec.exs
@@ -47,8 +47,7 @@ defmodule ZenEx.HelpCenter.Model.SectionSpec do
 
   describe "list" do
     before(
-      do:
-        mock(fn %{method: :get, url: _} -> %Tesla.Env{status: 200, body: json_sections()} end)
+      do: mock(fn %{method: :get, url: _} -> %Tesla.Env{status: 200, body: json_sections()} end)
     )
 
     it(do: expect(Model.Section.list("en-us") |> to(be_struct(ZenEx.Collection))))
@@ -58,8 +57,7 @@ defmodule ZenEx.HelpCenter.Model.SectionSpec do
 
   describe "show" do
     before(
-      do:
-        mock(fn %{method: :get, url: _} -> %Tesla.Env{status: 200, body: json_section()} end)
+      do: mock(fn %{method: :get, url: _} -> %Tesla.Env{status: 200, body: json_section()} end)
     )
 
     it(do: expect(Model.Section.show("en-us", section().id) |> to(eq(section()))))
@@ -67,8 +65,7 @@ defmodule ZenEx.HelpCenter.Model.SectionSpec do
 
   describe "create" do
     before(
-      do:
-        mock(fn %{method: :post, url: _} -> %Tesla.Env{status: 200, body: json_section()} end)
+      do: mock(fn %{method: :post, url: _} -> %Tesla.Env{status: 200, body: json_section()} end)
     )
 
     it(do: expect(Model.Section.create(section()) |> to(be_struct(Section))))
@@ -76,8 +73,7 @@ defmodule ZenEx.HelpCenter.Model.SectionSpec do
 
   describe "update" do
     before(
-      do:
-        mock(fn %{method: :put, url: _} -> %Tesla.Env{status: 200, body: json_section()} end)
+      do: mock(fn %{method: :put, url: _} -> %Tesla.Env{status: 200, body: json_section()} end)
     )
 
     it(do: expect(Model.Section.update(section()) |> to(be_struct(Section))))
@@ -85,19 +81,13 @@ defmodule ZenEx.HelpCenter.Model.SectionSpec do
 
   describe "destroy" do
     context "response status: 204" do
-      before(
-        do:
-          mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 204} end)
-      )
+      before(do: mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 204} end))
 
       it(do: expect(Model.Section.destroy(section().id) |> to(eq(:ok))))
     end
 
     context "response status: 404" do
-      before(
-        do:
-          mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 404} end)
-      )
+      before(do: mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 404} end))
 
       it(do: expect(Model.Section.destroy(section().id) |> to(eq(:error))))
     end

--- a/spec/zen_ex/help_center/models/section_spec.exs
+++ b/spec/zen_ex/help_center/models/section_spec.exs
@@ -45,15 +45,10 @@ defmodule ZenEx.HelpCenter.Model.SectionSpec do
       })
   )
 
-  let(:response_section, do: %Tesla.Env{body: json_section()})
-  let(:response_sections, do: %Tesla.Env{body: json_sections()})
-  let(:response_204, do: %Tesla.Env{status: 204})
-  let(:response_404, do: %Tesla.Env{status: 404})
-
   describe "list" do
     before(
       do:
-        mock(fn %{method: :get, url: _} -> %Tesla.Env{status: 200, body: response_sections()} end)
+        mock(fn %{method: :get, url: _} -> %Tesla.Env{status: 200, body: json_sections()} end)
     )
 
     it(do: expect(Model.Section.list("en-us") |> to(be_struct(ZenEx.Collection))))
@@ -64,7 +59,7 @@ defmodule ZenEx.HelpCenter.Model.SectionSpec do
   describe "show" do
     before(
       do:
-        mock(fn %{method: :get, url: _} -> %Tesla.Env{status: 200, body: response_section()} end)
+        mock(fn %{method: :get, url: _} -> %Tesla.Env{status: 200, body: json_section()} end)
     )
 
     it(do: expect(Model.Section.show("en-us", section().id) |> to(eq(section()))))
@@ -73,7 +68,7 @@ defmodule ZenEx.HelpCenter.Model.SectionSpec do
   describe "create" do
     before(
       do:
-        mock(fn %{method: :post, url: _} -> %Tesla.Env{status: 200, body: response_section()} end)
+        mock(fn %{method: :post, url: _} -> %Tesla.Env{status: 200, body: json_section()} end)
     )
 
     it(do: expect(Model.Section.create(section()) |> to(be_struct(Section))))
@@ -82,7 +77,7 @@ defmodule ZenEx.HelpCenter.Model.SectionSpec do
   describe "update" do
     before(
       do:
-        mock(fn %{method: :put, url: _} -> %Tesla.Env{status: 200, body: response_section()} end)
+        mock(fn %{method: :put, url: _} -> %Tesla.Env{status: 200, body: json_section()} end)
     )
 
     it(do: expect(Model.Section.update(section()) |> to(be_struct(Section))))
@@ -92,7 +87,7 @@ defmodule ZenEx.HelpCenter.Model.SectionSpec do
     context "response status: 204" do
       before(
         do:
-          mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 200, body: response_204()} end)
+          mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 204} end)
       )
 
       it(do: expect(Model.Section.destroy(section().id) |> to(eq(:ok))))
@@ -101,7 +96,7 @@ defmodule ZenEx.HelpCenter.Model.SectionSpec do
     context "response status: 404" do
       before(
         do:
-          mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 200, body: response_404()} end)
+          mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 404} end)
       )
 
       it(do: expect(Model.Section.destroy(section().id) |> to(eq(:error))))

--- a/spec/zen_ex/help_center/models/translation_spec.exs
+++ b/spec/zen_ex/help_center/models/translation_spec.exs
@@ -48,17 +48,11 @@ defmodule ZenEx.HelpCenter.Model.TranslationSpec do
     ~s({"locales":["en-us","ja"]})
   end
 
-  let(:response_translation, do: %Tesla.Env{body: json_translation()})
-  let(:response_translations, do: %Tesla.Env{body: json_translations()})
-  let(:response_locales, do: %Tesla.Env{body: json_locales()})
-  let(:response_204, do: %Tesla.Env{status: 204})
-  let(:response_404, do: %Tesla.Env{status: 404})
-
   describe "list" do
     before(
       do:
         mock(fn %{method: :get, url: _} ->
-          %Tesla.Env{status: 200, body: response_translations()}
+          %Tesla.Env{status: 200, body: json_translations()}
         end)
     )
 
@@ -71,7 +65,7 @@ defmodule ZenEx.HelpCenter.Model.TranslationSpec do
   describe "list_missing" do
     before(
       do:
-        mock(fn %{method: :get, url: _} -> %Tesla.Env{status: 200, body: response_locales()} end)
+        mock(fn %{method: :get, url: _} -> %Tesla.Env{status: 200, body: json_locales()} end)
     )
 
     it(do: expect(Model.Translation.list_missing(category_id: 1) |> to(eq(["en-us", "ja"]))))
@@ -83,7 +77,7 @@ defmodule ZenEx.HelpCenter.Model.TranslationSpec do
     before(
       do:
         mock(fn %{method: :get, url: _} ->
-          %Tesla.Env{status: 200, body: response_translation()}
+          %Tesla.Env{status: 200, body: json_translation()}
         end)
     )
 
@@ -94,7 +88,7 @@ defmodule ZenEx.HelpCenter.Model.TranslationSpec do
     before(
       do:
         mock(fn %{method: :post, url: _} ->
-          %Tesla.Env{status: 200, body: response_translation()}
+          %Tesla.Env{status: 200, body: json_translation()}
         end)
     )
 
@@ -127,7 +121,7 @@ defmodule ZenEx.HelpCenter.Model.TranslationSpec do
     before(
       do:
         mock(fn %{method: :put, url: _} ->
-          %Tesla.Env{status: 200, body: response_translation()}
+          %Tesla.Env{status: 200, body: json_translation()}
         end)
     )
 
@@ -160,7 +154,7 @@ defmodule ZenEx.HelpCenter.Model.TranslationSpec do
     context "response status: 204" do
       before(
         do:
-          mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 200, body: response_204()} end)
+          mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 204} end)
       )
 
       it(do: expect(Model.Translation.destroy(translation().id) |> to(eq(:ok))))
@@ -169,7 +163,7 @@ defmodule ZenEx.HelpCenter.Model.TranslationSpec do
     context "response status: 404" do
       before(
         do:
-          mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 200, body: response_404()} end)
+          mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 404} end)
       )
 
       it(do: expect(Model.Translation.destroy(translation().id) |> to(eq(:error))))

--- a/spec/zen_ex/help_center/models/translation_spec.exs
+++ b/spec/zen_ex/help_center/models/translation_spec.exs
@@ -64,8 +64,7 @@ defmodule ZenEx.HelpCenter.Model.TranslationSpec do
 
   describe "list_missing" do
     before(
-      do:
-        mock(fn %{method: :get, url: _} -> %Tesla.Env{status: 200, body: json_locales()} end)
+      do: mock(fn %{method: :get, url: _} -> %Tesla.Env{status: 200, body: json_locales()} end)
     )
 
     it(do: expect(Model.Translation.list_missing(category_id: 1) |> to(eq(["en-us", "ja"]))))
@@ -152,19 +151,13 @@ defmodule ZenEx.HelpCenter.Model.TranslationSpec do
 
   describe "destroy" do
     context "response status: 204" do
-      before(
-        do:
-          mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 204} end)
-      )
+      before(do: mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 204} end))
 
       it(do: expect(Model.Translation.destroy(translation().id) |> to(eq(:ok))))
     end
 
     context "response status: 404" do
-      before(
-        do:
-          mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 404} end)
-      )
+      before(do: mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 404} end))
 
       it(do: expect(Model.Translation.destroy(translation().id) |> to(eq(:error))))
     end


### PR DESCRIPTION
I'm not really sure how this module this was working before. The HTTP action functions (e.g.,
delete, get, post, put) were returning the body of a Tesla.Env. This was then piped to a
_build_entity function that was invoking body on its input (which was already the response body). 

Because _build_entity functions use pattern matching to match on a struct, I was seeing match errors as the body of
the response was JSON decoded by the JSON middleware and not a struct. Even if
I implemented _build_entity to match a map (which is what the JSON middleware
was returning), I'd encounter an exception attempting to call Poison.decode! on an
already decoded JSON string.

I am very likely missing something fundamental, but I'm not sure how versions from
0.4.4 to 0.6.0 (since the change to Tesla) worked at all. The specs pass because they mock the Tesla request and response and return a Tesla.Env that has another Tesla.Env as its body. I don't believe this mocks represent the actual responses from the HTTPClient though.

To get things working, I made the following changes:

* Use Tesla.Middleware.EncodeJson instead of Tesla.Middleware.JSON so we can
rely on the middelware to encode requests, but can rely on Poison to decode the response
bodies
* Action functions (delete/delete/post/put) return a Tesla.Env struct
* _build_entity functions match on a Tesla.Env, then use Poison.decode! to decode
the body string as the specified struct
* Updated all of the specs that were mocking Tesla responses to return strings as response
bodies

While using the current version (0.6.0), I encounter the following error attempting to get a user:

```
->>> ZenEx.Model.User.show(1904053427144)

** (FunctionClauseError) no function clause matching in ZenEx.HTTPClient._build_entity/2    
    
    The following arguments were given to ZenEx.HTTPClient._build_entity/2:
    
        # 1
        %{
          "user" => %{
            "user_fields" => %{},
            "id" => 1904053427144
          }
        }
    
        # 2
        [user: ZenEx.Entity.User]
    
    Attempted function clauses (showing 3 out of 3):
    
        def _build_entity(%_{} = res, [{key, [module]}])
        def _build_entity(%_{} = res, [{key, module}])
        def _build_entity({:error, error}, _)
    
    (zen_ex 0.6.0) lib/zen_ex/http_client.ex:60: ZenEx.HTTPClient._build_entity/2
```