### PR TITLE
Breaking change of function interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Add `zen_ex` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
-  [{:zen_ex, "~> 0.5.0"}]
+  [{:zen_ex, "~> 0.8.0"}]
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -35,154 +35,87 @@ See also: [Generating a new API token](https://support.zendesk.com/hc/en-us/arti
 
 ```elixir
 # List users
-users = ZenEx.Model.User.list.entities
+{:ok, %{entities: users}} = ZenEx.Model.User.list()
 
 # Show user
-user = ZenEx.Model.User.show(1)
+{:ok, user} = ZenEx.Model.User.show(1)
 
 # Create user
-user = ZenEx.Model.User.create(%ZenEx.Entity.User{name: "otoyo", email: "otoyo@otoyo.com"})
+{:ok, user} = ZenEx.Model.User.create(%ZenEx.Entity.User{name: "otoyo", email: "otoyo@otoyo.com"})
 
-# List tickets
-collection = ZenEx.Model.Ticket.list(per_page: 100, sort_order: "desc")
+# Paginate tickets
+{:ok, collection} = ZenEx.Model.Ticket.list(per_page: 100, sort_order: "desc")
 tickets = collection.entities
 next_tickets = collection |> ZenEx.Collection.next
 
 # Show ticket
-ticket = ZenEx.Model.Ticket.show(1)
+{:ok, %{entities: ticket}} = ZenEx.Model.Ticket.show(1)
 
 # Create ticket
-ticket = ZenEx.Model.Ticket.create(%ZenEx.Entity.Ticket{subject: "My printer is on fire!", description: "But no problem."})
+{:ok, ticket} = ZenEx.Model.Ticket.create(%ZenEx.Entity.Ticket{subject: "My printer is on fire!", description: "But no problem."})
 ```
 
-See also under ZenEx.Model.
+See also under `ZenEx.Model`.
 
 ## Supporting multiple Zendesk configs
 
 You may need to interact with more than one instance of Zendesk. In order to facilitate that there is a small override
 that can be put into the Process dictionary that will tell it to look for config settings keyed against a class name.
 
-For example:
+<details>
+  <summary>For details...</summary>
 
-config/config.exs
+  For example:
 
-```
-config :zen_ex,
-  subdomain: System.get_env("ZENDESK_SUBDOMAIN"),
-  user: System.get_env("ZENDESK_USER_EMAIL"),
-  api_token: System.get_env("ZENDESK_API_TOKEN")
+  config/config.exs
 
-config :zen_ex, ZendeskAlt,
-  subdomain: System.get_env("ZENDESK_ALT_SUBDOMAIN"),
-  user: System.get_env("ZENDESK_ALT_USER_EMAIL"),
-  api_token: System.get_env("ZENDESK_ALT_API_TOKEN")
-```
+  ```
+  config :zen_ex,
+    subdomain: System.get_env("ZENDESK_SUBDOMAIN"),
+    user: System.get_env("ZENDESK_USER_EMAIL"),
+    api_token: System.get_env("ZENDESK_API_TOKEN")
 
-Then whenever you want to use the alternate config, before using anything in the `zen_ex` library make sure to
-add a line of code like the following:
+  config :zen_ex, ZendeskAlt,
+    subdomain: System.get_env("ZENDESK_ALT_SUBDOMAIN"),
+    user: System.get_env("ZENDESK_ALT_USER_EMAIL"),
+    api_token: System.get_env("ZENDESK_ALT_API_TOKEN")
+  ```
 
-```
-Process.put(:zendesk_config_module, ZendeskAlt)
-```
+  Then whenever you want to use the alternate config, before using anything in the `zen_ex` library make sure to
+  add a line of code like the following:
 
-Anytime you use the zendesk library after that it will use the alternate config until you remove that process
-dictionary entry. It is good practice to put it back when you are done.
+  ```
+  Process.put(:zendesk_config_module, ZendeskAlt)
+  ```
 
-```
-Process.put(:zendesk_config_module, nil)
-```
+  Anytime you use the zendesk library after that it will use the alternate config until you remove that process
+  dictionary entry. It is good practice to put it back when you are done.
 
-If you do not add a `:zendesk_config_module` key to the Process dictionary then it will continue to use the
-default `zen_ex` config settings.
+  ```
+  Process.put(:zendesk_config_module, nil)
+  ```
+
+  If you do not add a `:zendesk_config_module` key to the Process dictionary then it will continue to use the
+  default `zen_ex` config settings.
+</details>
+
 
 ## Supported API
 
-### [Core API](https://developer.zendesk.com/rest_api/docs/core/introduction)
+| Capabilities | Entities |
+| --- | --- |
+| Ticketing | Users |
+| | User Identities |
+| | Tickets |
+| | Dynamic Content Items |
+| | Dynamic Content Item Variants |
+| | Locales |
+| | Job Statuses |
+| Help Center | Categories |
+| | Sections |
+| | Articles |
+| | Translations |
 
-- Users
-  - `list`
-  - `show`
-  - `create`
-  - `update`
-  - `create_or_update`
-  - `destroy`
-  - `create_many`
-  - `update_many`
-  - `create_or_update_many`
-  - `destroy_many`
-  - `search`
-- User Identities
-  - `list`
-  - `show`
-  - `create`
-  - `update`
-  - `make_primary`
-  - `verify`
-  - `request_user_verification`
-  - `delete`
-- Tickets
-  - `list`
-  - `show`
-  - `create`
-  - `update`
-  - `destroy`
-  - `create_many`
-  - `update_many`
-  - `destroy_many`
-- Dynamic contents
-  - `list`
-  - `show`
-  - `create`
-  - `update`
-  - `destroy`
-- Variants of dynamic contents
-  - `list`
-  - `show`
-  - `create`
-  - `create_many`
-  - `update`
-  - `update_many`
-  - `destroy`
-- Locales
-  - `show`
-- Job statuses
-  - `list`
-  - `show`
-  - `show_many`
+## Contribution
 
-### [Help Center API](https://developer.zendesk.com/rest_api/docs/help_center/introduction)
-
-- Categories
-  - `list`
-  - `show`
-  - `create`
-  - `update`
-  - `destroy`
-- Sections
-  - `list`
-  - `show`
-  - `create`
-  - `update`
-  - `destroy`
-- Articles
-  - `list`
-  - `show`
-  - `create`
-  - `update`
-  - `search`
-  - `destroy`
-- Translations
-  - `list`
-  - `list_missing`
-  - `show`
-  - `create`
-  - `update`
-  - `destroy`
-
-## Contributing
-
-Contributions are welcome ;)
-
-## LICENSE
-
-ZenEx is released under CC0-1.0 (see LICENSE).
+Please make an Issue or PR.

--- a/lib/zen_ex.ex
+++ b/lib/zen_ex.ex
@@ -5,7 +5,7 @@ defmodule ZenEx do
   ## Examples
 
       iex> ZenEx.Model.Ticket.list
-      [%ZenEx.Entity.Ticket{id: xxx, title: "xxx", ...}, ...]
+      {:ok, [%ZenEx.Entity.Ticket{id: xxx, title: "xxx", ...}, ...]}
 
   See under ZenEx.Model and ZenEx.Entity.
   """

--- a/lib/zen_ex/core/models/dynamic_content.ex
+++ b/lib/zen_ex/core/models/dynamic_content.ex
@@ -18,18 +18,20 @@ defmodule ZenEx.Model.DynamicContent do
   """
   @spec list :: {:ok, %ZenEx.Collection{}} | {:error, any()}
   def list(opts \\ []) when is_list(opts) do
-    with {:ok, collection} <-
-           HTTPClient.get("/api/v2/dynamic_content/items.json#{Query.build(opts)}",
-             items: [DynamicContent]
-           ) do
-      collection_with_variants =
-        Map.update(collection, :entities, [], fn dynamic_contents ->
-          Enum.map(dynamic_contents, &_build_variants/1)
-        end)
+    HTTPClient.get("/api/v2/dynamic_content/items.json#{Query.build(opts)}",
+      items: [DynamicContent]
+    )
+    |> case do
+      {:ok, collection} ->
+        collection_with_variants =
+          Map.update(collection, :entities, [], fn dynamic_contents ->
+            Enum.map(dynamic_contents, &_build_variants/1)
+          end)
 
-      {:ok, collection_with_variants}
-    else
-      {:error, err} -> {:error, err}
+        {:ok, collection_with_variants}
+
+      {:error, err} ->
+        {:error, err}
     end
   end
 

--- a/lib/zen_ex/core/models/dynamic_content/variant.ex
+++ b/lib/zen_ex/core/models/dynamic_content/variant.ex
@@ -14,10 +14,10 @@ defmodule ZenEx.Model.DynamicContent.Variant do
   ## Examples
 
       iex> ZenEx.Model.DynamicContent.Variant.list(xxx)
-      %ZenEx.Collection{}
+      {:ok, %ZenEx.Collection{}}
 
   """
-  @spec list(integer) :: %ZenEx.Collection{} | {:error, String.t()}
+  @spec list(integer) :: {:ok, %ZenEx.Collection{}} | {:error, any()}
   def list(dynamic_content_id, opts \\ [])
       when is_integer(dynamic_content_id) and is_list(opts) do
     "/api/v2/dynamic_content/items/#{dynamic_content_id}/variants.json#{Query.build(opts)}"
@@ -30,10 +30,10 @@ defmodule ZenEx.Model.DynamicContent.Variant do
   ## Examples
 
       iex> ZenEx.Model.DynamicContent.Variant.show(xxx)
-      %ZenEx.Entity.DynamicContent.Variant{id: xxx, default: xxx, content: "xxx", ...}
+      {:ok, %ZenEx.Entity.DynamicContent.Variant{id: xxx, default: xxx, content: "xxx", ...}}
 
   """
-  @spec show(integer, integer) :: %Variant{} | {:error, String.t()}
+  @spec show(integer, integer) :: {:ok, %Variant{}} | {:error, any()}
   def show(dynamic_content_id, variant_id)
       when is_integer(dynamic_content_id) and is_integer(variant_id) do
     HTTPClient.get(
@@ -48,10 +48,10 @@ defmodule ZenEx.Model.DynamicContent.Variant do
   ## Examples
 
       iex> ZenEx.Model.DynamicContent.Variant.create(%ZenEx.Entity.DynamicContent.Variant{id: xxx, default: xxx, content: "xxx", ...})
-      %ZenEx.Entity.DynamicContent.Variant{id: xxx, default: xxx, content: "xxx", ...}
+      {:ok, %ZenEx.Entity.DynamicContent.Variant{id: xxx, default: xxx, content: "xxx", ...}}
 
   """
-  @spec create(integer, %Variant{}) :: %Variant{} | {:error, String.t()}
+  @spec create(integer, %Variant{}) :: {:ok, %Variant{}} | {:error, any()}
   def create(dynamic_content_id, %Variant{} = variant) when is_integer(dynamic_content_id) do
     HTTPClient.post(
       "/api/v2/dynamic_content/items/#{dynamic_content_id}/variants.json",
@@ -66,10 +66,10 @@ defmodule ZenEx.Model.DynamicContent.Variant do
   ## Examples
 
       iex> ZenEx.Model.DynamicContent.Variant.create_many([%ZenEx.Entity.DynamicContent.Variant{id: xxx, default: xxx, content: "xxx", ...}, ...])
-      %ZenEx.Entity.JobStatus{id: "xxx"}
+      {:ok, %ZenEx.Entity.JobStatus{id: "xxx"}}
 
   """
-  @spec create_many(integer, list(%Variant{})) :: %JobStatus{} | {:error, String.t()}
+  @spec create_many(integer, list(%Variant{})) :: {:ok, %JobStatus{}} | {:error, any()}
   def create_many(dynamic_content_id, variants)
       when is_integer(dynamic_content_id) and is_list(variants) do
     HTTPClient.post(
@@ -85,10 +85,10 @@ defmodule ZenEx.Model.DynamicContent.Variant do
   ## Examples
 
       iex> ZenEx.Model.DynamicContent.Variant.update(%ZenEx.Entity.DynamicContent.Variant{id: xxx, default: xxx, content: "xxx", ...})
-      %ZenEx.Entity.DynamicContent.Variant{id: xxx, default: xxx, content: "xxx", ...}
+      {:ok, %ZenEx.Entity.DynamicContent.Variant{id: xxx, default: xxx, content: "xxx", ...}}
 
   """
-  @spec update(integer, %Variant{}) :: %Variant{} | {:error, String.t()}
+  @spec update(integer, %Variant{}) :: {:ok, %Variant{}} | {:error, any()}
   def update(dynamic_content_id, %Variant{} = variant) when is_integer(dynamic_content_id) do
     HTTPClient.put(
       "/api/v2/dynamic_content/items/#{dynamic_content_id}/variants/#{variant.id}.json",
@@ -103,10 +103,10 @@ defmodule ZenEx.Model.DynamicContent.Variant do
   ## Examples
 
       iex> ZenEx.Model.DynamicContent.Variant.update_many([%ZenEx.Entity.DynamicContent.Variant{id: xxx, default: xxx, content: "xxx", ...}, ...])
-      %ZenEx.Entity.JobStatus{id: "xxx"}
+      {:ok, %ZenEx.Entity.JobStatus{id: "xxx"}}
 
   """
-  @spec update_many(integer, list(%Variant{})) :: %JobStatus{} | {:error, String.t()}
+  @spec update_many(integer, list(%Variant{})) :: {:ok, %JobStatus{}} | {:error, any()}
   def update_many(dynamic_content_id, variants)
       when is_integer(dynamic_content_id) and is_list(variants) do
     HTTPClient.put(
@@ -125,14 +125,15 @@ defmodule ZenEx.Model.DynamicContent.Variant do
       :ok
 
   """
-  @spec destroy(integer, integer) :: :ok | :error
+  @spec destroy(integer, integer) :: :ok | {:error, any()}
   def destroy(dynamic_content_id, variant_id)
       when is_integer(dynamic_content_id) and is_integer(variant_id) do
-    case HTTPClient.delete(
-           "/api/v2/dynamic_content/items/#{dynamic_content_id}/variants/#{variant_id}.json"
-         ).status do
-      204 -> :ok
-      _ -> :error
+    HTTPClient.delete(
+      "/api/v2/dynamic_content/items/#{dynamic_content_id}/variants/#{variant_id}.json"
+    )
+    |> case do
+      {:ok, _} -> :ok
+      {:error, response} -> {:error, response}
     end
   end
 end

--- a/lib/zen_ex/core/models/job_status.ex
+++ b/lib/zen_ex/core/models/job_status.ex
@@ -13,10 +13,10 @@ defmodule ZenEx.Model.JobStatus do
   ## Examples
 
       iex> ZenEx.Model.JobStatus.list
-      %ZenEx.Collection{}
+      {:ok, %ZenEx.Collection{}}
 
   """
-  @spec list :: %ZenEx.Collection{} | {:error, String.t()}
+  @spec list :: {:ok, %ZenEx.Collection{}} | {:error, any()}
   def list(opts \\ []) when is_list(opts) do
     "/api/v2/job_statuses.json#{Query.build(opts)}"
     |> HTTPClient.get(job_statuses: [JobStatus])
@@ -28,10 +28,10 @@ defmodule ZenEx.Model.JobStatus do
   ## Examples
 
       iex> ZenEx.Model.JobStatus.show("xxx")
-      %ZenEx.Entity.JobStatus{id: "xxx", ...}
+      {:ok, %ZenEx.Entity.JobStatus{id: "xxx", ...}}
 
   """
-  @spec show(binary) :: %JobStatus{} | {:error, String.t()}
+  @spec show(binary) :: {:ok, %JobStatus{}} | {:error, any()}
   def show(id) when is_binary(id) do
     HTTPClient.get("/api/v2/job_statuses/#{id}.json", job_status: JobStatus)
   end
@@ -42,10 +42,10 @@ defmodule ZenEx.Model.JobStatus do
   ## Examples
 
       iex> ZenEx.Model.JobStatus.show_many(["xxx", ...])
-      %ZenEx.Collection{}
+      {:ok, %ZenEx.Collection{}}
 
   """
-  @spec show_many(list(binary)) :: %ZenEx.Collection{} | {:error, String.t()}
+  @spec show_many(list(binary)) :: {:ok, %ZenEx.Collection{}} | {:error, any()}
   def show_many(ids) when is_list(ids) do
     HTTPClient.get("/api/v2/job_statuses/show_many.json#{Query.build(ids: ids)}",
       job_statuses: [JobStatus]

--- a/lib/zen_ex/core/models/locale.ex
+++ b/lib/zen_ex/core/models/locale.ex
@@ -12,10 +12,10 @@ defmodule ZenEx.Model.Locale do
   ## Examples
 
       iex> ZenEx.Model.Locale.show("ja")
-      %ZenEx.Entity.Locale{id: 67, locale: "ja", ...}
+      {:ok, %ZenEx.Entity.Locale{id: 67, locale: "ja", ...}}
 
   """
-  @spec show(integer | String.t()) :: %Locale{} | {:error, String.t()}
+  @spec show(integer | String.t()) :: {:ok, %Locale{}} | {:error, any()}
   def show(id) do
     HTTPClient.get("/api/v2/locales/#{id}.json", locale: Locale)
   end

--- a/lib/zen_ex/core/models/ticket.ex
+++ b/lib/zen_ex/core/models/ticket.ex
@@ -14,10 +14,10 @@ defmodule ZenEx.Model.Ticket do
   ## Examples
 
       iex> ZenEx.Model.Ticket.list
-      %ZenEx.Collection{}
+      {:ok, %ZenEx.Collection{}}
 
   """
-  @spec list :: %ZenEx.Collection{} | {:error, String.t()}
+  @spec list :: {:ok, %ZenEx.Collection{}} | {:error, any()}
   def list(opts \\ []) when is_list(opts) do
     "/api/v2/tickets.json#{Query.build(opts)}"
     |> HTTPClient.get(tickets: [Ticket])
@@ -29,10 +29,10 @@ defmodule ZenEx.Model.Ticket do
   ## Examples
 
       iex> ZenEx.Model.Ticket.show(1)
-      %ZenEx.Entity.Ticket{id: 1, requester_id: xxx, subject: "Ticket Subject", description: "Ticket desc", ...}
+      {:ok, %ZenEx.Entity.Ticket{id: 1, requester_id: xxx, subject: "Ticket Subject", description: "Ticket desc", ...}}
 
   """
-  @spec show(integer) :: %Ticket{} | {:error, String.t()}
+  @spec show(integer) :: {:ok, %Ticket{}} | {:error, any()}
   def show(id) when is_integer(id) do
     HTTPClient.get("/api/v2/tickets/#{id}.json", ticket: Ticket)
   end
@@ -43,10 +43,10 @@ defmodule ZenEx.Model.Ticket do
   ## Examples
 
       iex> ZenEx.Model.Ticket.create(%ZenEx.Entity.Ticket{requester_id: xxx, subject: "Ticket Subject", description: "Ticket desc", ...})
-      %ZenEx.Entity.Ticket{requester_id: xxx, ...}
+      {:ok, %ZenEx.Entity.Ticket{requester_id: xxx, ...}}
 
   """
-  @spec create(%Ticket{}) :: %Ticket{} | {:error, String.t()}
+  @spec create(%Ticket{}) :: {:ok, %Ticket{}} | {:error, any()}
   def create(%Ticket{} = ticket) do
     HTTPClient.post("/api/v2/tickets.json", %{ticket: _desc_to_comment(ticket)}, ticket: Ticket)
   end
@@ -57,10 +57,10 @@ defmodule ZenEx.Model.Ticket do
   ## Examples
 
       iex> ZenEx.Model.Ticket.update(%ZenEx.Entity.Ticket{id: 1, requester_id: xxx, subject: "Ticket Subject", description: "Ticket desc", ...})
-      %ZenEx.Entity.Ticket{id: 1, requester_id: xxx, ...}
+      {:ok, %ZenEx.Entity.Ticket{id: 1, requester_id: xxx, ...}}
 
   """
-  @spec update(%Ticket{}) :: %Ticket{} | {:error, String.t()}
+  @spec update(%Ticket{}) :: {:ok, %Ticket{}} | {:error, any()}
   def update(%Ticket{} = ticket) do
     HTTPClient.put("/api/v2/tickets/#{ticket.id}.json", %{ticket: _desc_to_comment(ticket)},
       ticket: Ticket
@@ -73,14 +73,15 @@ defmodule ZenEx.Model.Ticket do
   ## Examples
 
       iex> ZenEx.Model.Ticket.destroy(1)
-      :ok
+      {:ok, %ZenEx.Entity.Ticket{requester_id: xxx, ...}}
 
   """
-  @spec destroy(integer) :: :ok | :error
+  @spec destroy(integer) :: :ok | {:error, any()}
   def destroy(id) when is_integer(id) do
-    case HTTPClient.delete("/api/v2/tickets/#{id}.json").status do
-      204 -> :ok
-      _ -> :error
+    HTTPClient.delete("/api/v2/tickets/#{id}.json")
+    |> case do
+      {:ok, _} -> :ok
+      {:error, response} -> {:error, response}
     end
   end
 
@@ -90,10 +91,10 @@ defmodule ZenEx.Model.Ticket do
   ## Examples
 
       iex> ZenEx.Model.Ticket.create_many([%ZenEx.Entity.Ticket{requester_id: xxx, subject: "Ticket Subject", description: "Ticket desc", ...}, ...])
-      %ZenEx.Entity.JobStatus{id: "xxx"}
+      {:ok, %ZenEx.Entity.JobStatus{id: "xxx"}}
 
   """
-  @spec create_many(list(%Ticket{})) :: %JobStatus{} | {:error, String.t()}
+  @spec create_many(list(%Ticket{})) :: {:ok, %JobStatus{}} | {:error, any()}
   def create_many(tickets) when is_list(tickets) do
     HTTPClient.post("/api/v2/tickets/create_many.json", %{tickets: _desc_to_comment(tickets)},
       job_status: JobStatus
@@ -106,10 +107,10 @@ defmodule ZenEx.Model.Ticket do
   ## Examples
 
       iex> ZenEx.Model.Ticket.update_many([%ZenEx.Entity.Ticket{id: xxx, requester_id: xxx, subject: "Ticket Subject", description: "Ticket desc", ...}, ...])
-      %ZenEx.Entity.JobStatus{id: "xxx"}
+      {:ok, %ZenEx.Entity.JobStatus{id: "xxx"}}
 
   """
-  @spec update_many(list(%Ticket{})) :: %JobStatus{} | {:error, String.t()}
+  @spec update_many(list(%Ticket{})) :: {:ok, %JobStatus{}} | {:error, any()}
   def update_many(tickets) when is_list(tickets) do
     HTTPClient.put("/api/v2/tickets/update_many.json", %{tickets: _desc_to_comment(tickets)},
       job_status: JobStatus
@@ -122,10 +123,10 @@ defmodule ZenEx.Model.Ticket do
   ## Examples
 
       iex> ZenEx.Model.Ticket.destroy_many([xxx, ...])
-      %ZenEx.Entity.JobStatus{id: "xxx"}
+      {:ok, %ZenEx.Entity.JobStatus{id: "xxx"}}
 
   """
-  @spec destroy_many(list(integer)) :: %JobStatus{} | {:error, String.t()}
+  @spec destroy_many(list(integer)) :: {:ok, %JobStatus{}} | {:error, any()}
   def destroy_many(ids) when is_list(ids) do
     HTTPClient.delete("/api/v2/tickets/destroy_many.json?ids=#{Enum.join(ids, ",")}",
       job_status: JobStatus
@@ -138,18 +139,18 @@ defmodule ZenEx.Model.Ticket do
   ## Examples
 
       iex> ZenEx.Model.User.search(%{email: "first.last@domain.com"})
-      %ZenEx.Collection{}
+      {:ok, %ZenEx.Collection{}}
 
       iex> ZenEx.Model.User.search("David"})
-      %ZenEx.Collection{}
+      {:ok, %ZenEx.Collection{}}
 
   """
-  @spec search(map()) :: %ZenEx.Collection{} | {:error, String.t()}
+  @spec search(map()) :: {:ok, %ZenEx.Collection{}} | {:error, any()}
   def search(opts) when is_map(opts) do
     search(SearchQuery.build(opts))
   end
 
-  @spec search(String.t()) :: %ZenEx.Collection{} | {:error, String.t()}
+  @spec search(String.t()) :: {:ok, %ZenEx.Collection{}} | {:error, any()}
   def search(query) do
     "/api/v2/users/search.json?query=type:ticket #{query}"
     |> HTTPClient.get(results: [Ticket])

--- a/lib/zen_ex/core/models/user.ex
+++ b/lib/zen_ex/core/models/user.ex
@@ -14,10 +14,10 @@ defmodule ZenEx.Model.User do
   ## Examples
 
       iex> ZenEx.Model.User.list
-      %ZenEx.Collection{}
+      {:ok, %ZenEx.Collection{}}
 
   """
-  @spec list :: %ZenEx.Collection{} | {:error, String.t()}
+  @spec list :: {:ok, %ZenEx.Collection{}} | {:error, any()}
   def list(opts \\ []) when is_list(opts) do
     "/api/v2/users.json#{Query.build(opts)}"
     |> HTTPClient.get(users: [User])
@@ -29,10 +29,10 @@ defmodule ZenEx.Model.User do
   ## Examples
 
       iex> ZenEx.Model.User.show(1)
-      %ZenEx.Entity.User{id: 1, name: "xxx", ...}
+      {:ok, %ZenEx.Entity.User{id: 1, name: "xxx", ...}}
 
   """
-  @spec show(integer) :: %User{} | {:error, String.t()}
+  @spec show(integer) :: {:ok, %User{}} | {:error, any()}
   def show(id) when is_integer(id) do
     HTTPClient.get("/api/v2/users/#{id}.json", user: User)
   end
@@ -43,10 +43,10 @@ defmodule ZenEx.Model.User do
   ## Examples
 
       iex> ZenEx.Model.User.create(%ZenEx.Entity.User{name: "xxx", email: "xxx@xxx"})
-      %ZenEx.Entity.User{name: "xxx", email: "xxx@xxx", ...}
+      {:ok, %ZenEx.Entity.User{name: "xxx", email: "xxx@xxx", ...}}
 
   """
-  @spec create(%User{}) :: %User{} | {:error, String.t()} | nil
+  @spec create(%User{}) :: {:ok, %User{}} | {:error, any()}
   def create(%User{} = user) do
     HTTPClient.post("/api/v2/users.json", %{user: user}, user: User)
   end
@@ -57,10 +57,10 @@ defmodule ZenEx.Model.User do
   ## Examples
 
       iex> ZenEx.Model.User.update(%ZenEx.Entity.User{id: 1, name: "xxx"})
-      %ZenEx.Entity.User{id: 1, name: "xxx", ...}
+      {:ok, %ZenEx.Entity.User{id: 1, name: "xxx", ...}}
 
   """
-  @spec update(%User{}) :: %User{} | {:error, String.t()}
+  @spec update(%User{}) :: {:ok, %User{}} | {:error, any()}
   def update(%User{} = user) do
     HTTPClient.put("/api/v2/users/#{user.id}.json", %{user: user}, user: User)
   end
@@ -71,10 +71,10 @@ defmodule ZenEx.Model.User do
   ## Examples
 
       iex> ZenEx.Model.User.create_or_update(%ZenEx.Entity.User{name: "xxx", email: "xxx@xxx"})
-      %ZenEx.Entity.User{id: xxx, name: "xxx", email: "xxx@xxx", ...}
+      {:ok, %ZenEx.Entity.User{id: xxx, name: "xxx", email: "xxx@xxx", ...}}
 
   """
-  @spec create_or_update(%User{}) :: %User{} | {:error, String.t()}
+  @spec create_or_update(%User{}) :: {:ok, %User{}} | {:error, any()}
   def create_or_update(%User{} = user) do
     HTTPClient.post("/api/v2/users/create_or_update.json", %{user: user}, user: User)
   end
@@ -85,10 +85,10 @@ defmodule ZenEx.Model.User do
   ## Examples
 
       iex> ZenEx.Model.User.destroy(1)
-      %ZenEx.Entity.User{id: 1, name: "xxx", active: false, ...}
+      :ok
 
   """
-  @spec destroy(integer) :: %User{} | {:error, String.t()}
+  @spec destroy(integer) :: {:ok, %User{}} | {:error, any()}
   def destroy(id) when is_integer(id) do
     HTTPClient.delete("/api/v2/users/#{id}.json", user: User)
   end
@@ -99,10 +99,10 @@ defmodule ZenEx.Model.User do
   ## Examples
 
       iex> ZenEx.Model.User.permanently_destroy(1)
-      %ZenEx.Entity.User{id: 1, name: "xxx", active: false, ...}
+      :ok
 
   """
-  @spec permanently_destroy(integer) :: %User{} | {:error, String.t()}
+  @spec permanently_destroy(integer) :: {:ok, %User{}} | {:error, any()}
   def permanently_destroy(id) when is_integer(id) do
     HTTPClient.delete("/api/v2/deleted_users/#{id}.json", deleted_user: User)
   end
@@ -113,10 +113,10 @@ defmodule ZenEx.Model.User do
   ## Examples
 
       iex> ZenEx.Model.User.create_many([%ZenEx.Entity.User{name: "xxx"}, ...])
-      %ZenEx.Entity.JobStatus{id: "xxx"}
+      {:ok, %ZenEx.Entity.JobStatus{id: "xxx"}}
 
   """
-  @spec create_many(list(%User{})) :: %JobStatus{} | {:error, String.t()}
+  @spec create_many(list(%User{})) :: {:ok, %JobStatus{}} | {:error, any()}
   def create_many(users) when is_list(users) do
     HTTPClient.post("/api/v2/users/create_many.json", %{users: users}, job_status: JobStatus)
   end
@@ -127,10 +127,10 @@ defmodule ZenEx.Model.User do
   ## Examples
 
       iex> ZenEx.Model.User.update_many([%ZenEx.Entity.User{id: xxx, name: "xxx"}, ...])
-      %ZenEx.Entity.JobStatus{id: "xxx"}
+      {:ok, %ZenEx.Entity.JobStatus{id: "xxx"}}
 
   """
-  @spec update_many(list(%User{})) :: %JobStatus{} | {:error, String.t()}
+  @spec update_many(list(%User{})) :: {:ok, %JobStatus{}} | {:error, any()}
   def update_many(users) when is_list(users) do
     HTTPClient.put("/api/v2/users/update_many.json", %{users: users}, job_status: JobStatus)
   end
@@ -141,10 +141,10 @@ defmodule ZenEx.Model.User do
   ## Examples
 
       iex> ZenEx.Model.User.create_or_update_many([%ZenEx.Entity.User{id: xxx, name: "xxx"}, ...])
-      %ZenEx.Entity.JobStatus{id: "xxx"}
+      {:ok, %ZenEx.Entity.JobStatus{id: "xxx"}}
 
   """
-  @spec create_or_update_many(list(%User{})) :: %JobStatus{} | {:error, String.t()}
+  @spec create_or_update_many(list(%User{})) :: {:ok, %JobStatus{}} | {:error, any()}
   def create_or_update_many(users) when is_list(users) do
     HTTPClient.post("/api/v2/users/create_or_update_many.json", %{users: users},
       job_status: JobStatus
@@ -157,10 +157,10 @@ defmodule ZenEx.Model.User do
   ## Examples
 
       iex> ZenEx.Model.User.destroy_many([xxx, ...])
-      %ZenEx.Entity.JobStatus{id: "xxx"}
+      {:ok, %ZenEx.Entity.JobStatus{id: "xxx"}}
 
   """
-  @spec destroy_many(list(integer)) :: %JobStatus{} | {:error, String.t()}
+  @spec destroy_many(list(integer)) :: {:ok, %JobStatus{}} | {:error, any()}
   def destroy_many(ids) when is_list(ids) do
     HTTPClient.delete("/api/v2/users/destroy_many.json?ids=#{Enum.join(ids, ",")}",
       job_status: JobStatus
@@ -173,18 +173,18 @@ defmodule ZenEx.Model.User do
   ## Examples
 
       iex> ZenEx.Model.User.search(%{email: "first.last@domain.com"})
-      %ZenEx.Collection{}
+      {:ok, %ZenEx.Collection{}}
 
       iex> ZenEx.Model.User.search("David"})
-      %ZenEx.Collection{}
+      {:ok, %ZenEx.Collection{}}
 
   """
-  @spec search(map()) :: %ZenEx.Collection{} | {:error, String.t()}
+  @spec search(map()) :: {:ok, %ZenEx.Collection{}} | {:error, any()}
   def search(opts) when is_map(opts) do
     search(SearchQuery.build(opts))
   end
 
-  @spec search(String.t()) :: %ZenEx.Collection{} | {:error, String.t()}
+  @spec search(String.t()) :: {:ok, %ZenEx.Collection{}} | {:error, any()}
   def search(query) do
     "/api/v2/users/search.json?query=#{query}"
     |> HTTPClient.get(users: [User])

--- a/lib/zen_ex/core/models/user_identity.ex
+++ b/lib/zen_ex/core/models/user_identity.ex
@@ -13,10 +13,10 @@ defmodule ZenEx.Model.UserIdentity do
   ## Examples
 
       iex> ZenEx.Model.UserIdentity.list(%ZenEx.Entity.User{id: xxx})
-      %ZenEx.Collection{}
+      {:ok, %ZenEx.Collection{}}
 
   """
-  @spec list(%User{}) :: %ZenEx.Collection{} | {:error, String.t()}
+  @spec list(%User{}) :: {:ok, %ZenEx.Collection{}} | {:error, any()}
   def list(%User{id: user_id}, opts \\ []) when is_list(opts) do
     "/api/v2/users/#{user_id}/identities#{Query.build(opts)}"
     |> HTTPClient.get(identities: [UserIdentity])
@@ -27,11 +27,11 @@ defmodule ZenEx.Model.UserIdentity do
 
   ## Examples
 
-      iex> ZenEx.Model.UserIdentity.show(%ZenEx.Entity.User{id: xxx}, 1)
-      %ZenEx.Entity.UserIdentity{id: 1, type: "xxx", ...}
+     iex> ZenEx.Model.UserIdentity.show(%ZenEx.Entity.User{id: xxx}, 1)
+     {:ok, %ZenEx.Entity.UserIdentity{id: 1, type: "xxx", ...}}
 
   """
-  @spec show(%User{}, integer) :: %UserIdentity{} | {:error, String.t()}
+  @spec show(%User{}, integer) :: {:ok, %UserIdentity{}} | {:error, any()}
   def show(%User{id: user_id}, id) when is_integer(id) do
     HTTPClient.get("/api/v2/users/#{user_id}/identities/#{id}.json", identity: UserIdentity)
   end
@@ -41,11 +41,11 @@ defmodule ZenEx.Model.UserIdentity do
 
   ## Examples
 
-      iex> ZenEx.Model.UserIdentity.create(%ZenEx.Entity.User{id: xxx}, %ZenEx.Entity.UserIdentity{type: "xxx", value: "xxx"})
-      %ZenEx.Entity.UserIdentity{id: xxx, value: "xxx", ...}
+     iex> ZenEx.Model.UserIdentity.create(%ZenEx.Entity.User{id: xxx}, %ZenEx.Entity.UserIdentity{type: "xxx", value: "xxx"})
+     {:ok, %ZenEx.Entity.UserIdentity{id: xxx, value: "xxx", ...}}
 
   """
-  @spec create(%User{}, %UserIdentity{}) :: %UserIdentity{} | {:error, String.t()} | nil
+  @spec create(%User{}, %UserIdentity{}) :: {:ok, %UserIdentity{}} | {:error, any()}
   def create(%User{id: user_id}, %UserIdentity{} = identity) do
     HTTPClient.post("/api/v2/users/#{user_id}/identities.json", %{identity: identity},
       identity: UserIdentity
@@ -57,11 +57,11 @@ defmodule ZenEx.Model.UserIdentity do
 
   ## Examples
 
-      iex> ZenEx.Model.UserIdentity.update(%ZenEx.Entity.User{id: 1}, %ZenEx.Entity.UserIdentity{id: xxx, type: "xxx"})
-      %ZenEx.Entity.UserIdentity{id: 1, type: "xxx", ...}
+     iex> ZenEx.Model.UserIdentity.update(%ZenEx.Entity.User{id: 1}, %ZenEx.Entity.UserIdentity{id: xxx, type: "xxx"})
+     {:ok, %ZenEx.Entity.UserIdentity{id: 1, type: "xxx", ...}}
 
   """
-  @spec update(%User{}, %UserIdentity{}) :: %UserIdentity{} | {:error, String.t()}
+  @spec update(%User{}, %UserIdentity{}) :: {:ok, %UserIdentity{}} | {:error, any()}
   def update(%User{id: user_id}, %UserIdentity{} = identity) do
     HTTPClient.put(
       "/api/v2/users/#{user_id}/identities/#{identity.id}.json",
@@ -75,11 +75,11 @@ defmodule ZenEx.Model.UserIdentity do
 
   ## Examples
 
-      iex> ZenEx.Model.UserIdentity.make_primary(%ZenEx.Entity.User{id: 1}, 1)
-      %ZenEx.Collection{}
+     iex> ZenEx.Model.UserIdentity.make_primary(%ZenEx.Entity.User{id: 1}, 1)
+     {:ok, %ZenEx.Collection{}}
 
   """
-  @spec make_primary(%User{}, integer) :: %ZenEx.Collection{} | {:error, String.t()}
+  @spec make_primary(%User{}, integer) :: {:ok, %ZenEx.Collection{}} | {:error, any()}
   def make_primary(%User{id: user_id}, id) when is_integer(id) do
     HTTPClient.put("/api/v2/users/#{user_id}/identities/#{id}/make_primary", %{},
       identities: [UserIdentity]
@@ -91,15 +91,16 @@ defmodule ZenEx.Model.UserIdentity do
 
   ## Examples
 
-      iex> ZenEx.Model.UserIdentity.verify(%ZenEx.Entity.User{id: 1}, 1)
-      :ok
+     iex> ZenEx.Model.UserIdentity.verify(%ZenEx.Entity.User{id: 1}, 1)
+     :ok
 
   """
-  @spec verify(%User{}, integer) :: :ok | :error
+  @spec verify(%User{}, integer) :: :ok | {:error, any()}
   def verify(%User{id: user_id}, id) when is_integer(id) do
-    case HTTPClient.put("/api/v2/users/#{user_id}/identities/#{id}/verify", %{}).status do
-      200 -> :ok
-      _ -> :error
+    HTTPClient.put("/api/v2/users/#{user_id}/identities/#{id}/verify", %{})
+    |> case do
+      {:ok, _} -> :ok
+      {:error, response} -> {:error, response}
     end
   end
 
@@ -108,15 +109,16 @@ defmodule ZenEx.Model.UserIdentity do
 
   ## Examples
 
-      iex> ZenEx.Model.UserIdentity.request_user_verification(%ZenEx.Entity.User{id: 1}, 1)
-      %ZenEx.Collection{}
+     iex> ZenEx.Model.UserIdentity.request_user_verification(%ZenEx.Entity.User{id: 1}, 1)
+     :ok
 
   """
-  @spec request_user_verification(%User{}, integer) :: :ok | :error
+  @spec request_user_verification(%User{}, integer) :: :ok | {:error, any()}
   def request_user_verification(%User{id: user_id}, id) when is_integer(id) do
-    case HTTPClient.put("/api/v2/users/#{user_id}/identities/#{id}/request_verification", %{}).status do
-      200 -> :ok
-      _ -> :error
+    HTTPClient.put("/api/v2/users/#{user_id}/identities/#{id}/request_verification", %{})
+    |> case do
+      {:ok, _} -> :ok
+      {:error, response} -> {:error, response}
     end
   end
 
@@ -125,15 +127,16 @@ defmodule ZenEx.Model.UserIdentity do
 
   ## Examples
 
-      iex> ZenEx.Model.UserIdentity.destroy(%ZenEx.Entity.User{id: 1}, 1)
-      :ok
+     iex> ZenEx.Model.UserIdentity.destroy(%ZenEx.Entity.User{id: 1}, 1)
+     :ok
 
   """
-  @spec destroy(%User{}, integer) :: :ok | :error
+  @spec destroy(%User{}, integer) :: :ok | {:error, any()}
   def destroy(%User{id: user_id}, id) when is_integer(id) do
-    case HTTPClient.delete("/api/v2/users/#{user_id}/identities/#{id}.json").status do
-      204 -> :ok
-      _ -> :error
+    HTTPClient.delete("/api/v2/users/#{user_id}/identities/#{id}.json")
+    |> case do
+      {:ok, _} -> :ok
+      {:error, response} -> {:error, response}
     end
   end
 end

--- a/lib/zen_ex/help_center/models/article.ex
+++ b/lib/zen_ex/help_center/models/article.ex
@@ -14,13 +14,13 @@ defmodule ZenEx.HelpCenter.Model.Article do
   ## Examples
 
       iex> ZenEx.HelpCenter.Model.Article.list("en-us")
-      %ZenEx.Collection{}
+      {:ok, %ZenEx.Collection{}}
 
       iex> ZenEx.HelpCenter.Model.Article.list("en-us", 1)
-      %ZenEx.Collection{}
+      {:ok, %ZenEx.Collection{}}
 
   """
-  @spec list(keyword()) :: %ZenEx.Collection{}
+  @spec list(keyword()) :: {:ok, %ZenEx.Collection{}} | {:error, any()}
   def list(locale, section_id_or_opts \\ [], opts \\ []) when is_list(opts) do
     case section_id_or_opts do
       section_id when is_integer(section_id) ->
@@ -38,10 +38,10 @@ defmodule ZenEx.HelpCenter.Model.Article do
   ## Examples
 
       iex> ZenEx.HelpCenter.Model.Article.show("en-us", 1)
-      %ZenEx.HelpCenter.Entity.Article{id: 1, name: xxx, locale: "en-us", ...}
+      {:ok, %ZenEx.HelpCenter.Entity.Article{id: 1, name: xxx, locale: "en-us", ...}}
 
   """
-  @spec show(String.t(), integer) :: %Article{}
+  @spec show(String.t(), integer) :: {:ok, %Article{}} | {:error, any()}
   def show(locale, id) when is_integer(id) do
     HTTPClient.get("/api/v2/help_center/#{locale}/articles/#{id}.json", article: Article)
   end
@@ -52,10 +52,10 @@ defmodule ZenEx.HelpCenter.Model.Article do
   ## Examples
 
       iex> ZenEx.HelpCenter.Model.Article.create(%ZenEx.HelpCenter.Entity.Article{name: xxx, locale: xxx, ...})
-      %ZenEx.HelpCenter.Entity.Article{name: xxx, locale: xxx, ...}
+      {:ok, %ZenEx.HelpCenter.Entity.Article{name: xxx, locale: xxx, ...}}
 
   """
-  @spec create(%Article{}) :: %Article{}
+  @spec create(%Article{}) :: {:ok, %Article{}} | {:error, any()}
   def create(%Article{} = article) do
     HTTPClient.post("/api/v2/help_center/articles.json", %{article: article}, article: Article)
   end
@@ -66,10 +66,10 @@ defmodule ZenEx.HelpCenter.Model.Article do
   ## Examples
 
       iex> ZenEx.HelpCenter.Model.Article.update(%ZenEx.HelpCenter.Entity.Article{id: 1, name: xxx, locale: xxx, ...})
-      %ZenEx.HelpCenter.Entity.Article{id: 1, name: xxx, locale: xxx, ...}
+      {:ok, %ZenEx.HelpCenter.Entity.Article{id: 1, name: xxx, locale: xxx, ...}}
 
   """
-  @spec update(%Article{}) :: %Article{}
+  @spec update(%Article{}) :: {:ok, %Article{}} | {:error, any()}
   def update(%Article{} = article) do
     HTTPClient.put("/api/v2/help_center/articles/#{article.id}.json", %{article: article},
       article: Article
@@ -85,11 +85,12 @@ defmodule ZenEx.HelpCenter.Model.Article do
       :ok
 
   """
-  @spec destroy(integer) :: :ok | :error
+  @spec destroy(integer) :: :ok | {:error, any()}
   def destroy(id) when is_integer(id) do
-    case HTTPClient.delete("/api/v2/help_center/articles/#{id}.json").status do
-      204 -> :ok
-      _ -> :error
+    HTTPClient.delete("/api/v2/help_center/articles/#{id}.json")
+    |> case do
+      {:ok, _} -> :ok
+      {:error, response} -> {:error, response}
     end
   end
 
@@ -99,10 +100,10 @@ defmodule ZenEx.HelpCenter.Model.Article do
   ## Examples
 
       iex> ZenEx.HelpCenter.Model.Article.search("query={search_string}&updated_after=2017-01-01")
-      %ZenEx.Collection{}
+      {:ok, %ZenEx.Collection{}}
 
   """
-  @spec search(String.t()) :: %ZenEx.Collection{}
+  @spec search(String.t()) :: {:ok, %ZenEx.Collection{}} | {:error, any()}
   def search(query) do
     HTTPClient.get("/api/v2/help_center/articles/search.json?#{query}", results: [Article])
   end

--- a/lib/zen_ex/help_center/models/category.ex
+++ b/lib/zen_ex/help_center/models/category.ex
@@ -13,10 +13,10 @@ defmodule ZenEx.HelpCenter.Model.Category do
   ## Examples
 
       iex> ZenEx.HelpCenter.Model.Category.list("en-us")
-      %ZenEx.Collection{}
+      {:ok, %ZenEx.Collection{}}
 
   """
-  @spec list(keyword()) :: %ZenEx.Collection{}
+  @spec list(keyword()) :: {:ok, %ZenEx.Collection{}} | {:error, any()}
   def list(locale, opts \\ []) when is_list(opts) do
     "/api/v2/help_center/#{locale}/categories.json#{Query.build(opts)}"
     |> HTTPClient.get(categories: [Category])
@@ -28,10 +28,10 @@ defmodule ZenEx.HelpCenter.Model.Category do
   ## Examples
 
       iex> ZenEx.HelpCenter.Model.Category.show("en-us", 1)
-      %ZenEx.HelpCenter.Entity.Category{id: 1, name: xxx, locale: "en-us", ...}
+      {:ok, %ZenEx.HelpCenter.Entity.Category{id: 1, name: xxx, locale: "en-us", ...}}
 
   """
-  @spec show(String.t(), integer) :: %Category{}
+  @spec show(String.t(), integer) :: {:ok, %Category{}} | {:error, any()}
   def show(locale, id) when is_integer(id) do
     HTTPClient.get("/api/v2/help_center/#{locale}/categories/#{id}.json", category: Category)
   end
@@ -42,10 +42,10 @@ defmodule ZenEx.HelpCenter.Model.Category do
   ## Examples
 
       iex> ZenEx.HelpCenter.Model.Category.create(%ZenEx.HelpCenter.Entity.Category{name: xxx, locale: xxx, ...})
-      %ZenEx.HelpCenter.Entity.Category{name: xxx, locale: xxx, ...}
+      {:ok, %ZenEx.HelpCenter.Entity.Category{name: xxx, locale: xxx, ...}}
 
   """
-  @spec create(%Category{}) :: %Category{}
+  @spec create(%Category{}) :: {:ok, %Category{}} | {:error, any()}
   def create(%Category{} = category) do
     HTTPClient.post("/api/v2/help_center/categories.json", %{category: category},
       category: Category
@@ -58,10 +58,10 @@ defmodule ZenEx.HelpCenter.Model.Category do
   ## Examples
 
       iex> ZenEx.HelpCenter.Model.Category.update(%ZenEx.HelpCenter.Entity.Category{id: 1, name: xxx, locale: xxx, ...})
-      %ZenEx.HelpCenter.Entity.Category{id: 1, name: xxx, locale: xxx, ...}
+      {:ok, %ZenEx.HelpCenter.Entity.Category{id: 1, name: xxx, locale: xxx, ...}}
 
   """
-  @spec update(%Category{}) :: %Category{}
+  @spec update(%Category{}) :: {:ok, %Category{}} | {:error, any()}
   def update(%Category{} = category) do
     HTTPClient.put("/api/v2/help_center/categories/#{category.id}.json", %{category: category},
       category: Category
@@ -77,11 +77,12 @@ defmodule ZenEx.HelpCenter.Model.Category do
       :ok
 
   """
-  @spec destroy(integer) :: :ok | :error
+  @spec destroy(integer) :: :ok | {:error, any()}
   def destroy(id) when is_integer(id) do
-    case HTTPClient.delete("/api/v2/help_center/categories/#{id}.json").status do
-      204 -> :ok
-      _ -> :error
+    HTTPClient.delete("/api/v2/help_center/categories/#{id}.json")
+    |> case do
+      {:ok, _} -> :ok
+      {:error, response} -> {:error, response}
     end
   end
 end

--- a/lib/zen_ex/help_center/models/section.ex
+++ b/lib/zen_ex/help_center/models/section.ex
@@ -14,13 +14,13 @@ defmodule ZenEx.HelpCenter.Model.Section do
   ## Examples
 
       iex> ZenEx.HelpCenter.Model.Section.list("en-us")
-      %ZenEx.Collection{}
+      {:ok, %ZenEx.Collection{}}
 
       iex> ZenEx.HelpCenter.Model.Section.list("en-us", 1)
-      %ZenEx.Collection{}
+      {:ok, %ZenEx.Collection{}}
 
   """
-  @spec list(String.t()) :: %ZenEx.Collection{}
+  @spec list(String.t()) :: {:ok, %ZenEx.Collection{}} | {:error, any()}
   def list(locale, category_id_or_opts \\ [], opts \\ []) when is_list(opts) do
     case category_id_or_opts do
       category_id when is_integer(category_id) ->
@@ -38,10 +38,10 @@ defmodule ZenEx.HelpCenter.Model.Section do
   ## Examples
 
       iex> ZenEx.HelpCenter.Model.Section.show("en-us", 1)
-      %ZenEx.HelpCenter.Entity.Section{id: 1, name: xxx, locale: "en-us", ...}
+      {:ok, %ZenEx.HelpCenter.Entity.Section{id: 1, name: xxx, locale: "en-us", ...}}
 
   """
-  @spec show(String.t(), integer) :: %Section{}
+  @spec show(String.t(), integer) :: {:ok, %Section{}} | {:error, any()}
   def show(locale, id) when is_integer(id) do
     HTTPClient.get("/api/v2/help_center/#{locale}/sections/#{id}.json", section: Section)
   end
@@ -52,10 +52,10 @@ defmodule ZenEx.HelpCenter.Model.Section do
   ## Examples
 
       iex> ZenEx.HelpCenter.Model.Section.create(%ZenEx.HelpCenter.Entity.Section{name: xxx, locale: xxx, ...})
-      %ZenEx.HelpCenter.Entity.Section{name: xxx, locale: xxx, ...}
+      {:ok, %ZenEx.HelpCenter.Entity.Section{name: xxx, locale: xxx, ...}}
 
   """
-  @spec create(%Section{}) :: %Section{}
+  @spec create(%Section{}) :: {:ok, %Section{}} | {:error, any()}
   def create(%Section{} = section) do
     HTTPClient.post("/api/v2/help_center/sections.json", %{section: section}, section: Section)
   end
@@ -66,10 +66,10 @@ defmodule ZenEx.HelpCenter.Model.Section do
   ## Examples
 
       iex> ZenEx.HelpCenter.Model.Section.update(%ZenEx.HelpCenter.Entity.Section{id: 1, name: xxx, locale: xxx, ...})
-      %ZenEx.HelpCenter.Entity.Section{id: 1, name: xxx, locale: xxx, ...}
+      {:ok, %ZenEx.HelpCenter.Entity.Section{id: 1, name: xxx, locale: xxx, ...}}
 
   """
-  @spec update(%Section{}) :: %Section{}
+  @spec update(%Section{}) :: {:ok, %Section{}} | {:error, any()}
   def update(%Section{} = section) do
     HTTPClient.put("/api/v2/help_center/sections/#{section.id}.json", %{section: section},
       section: Section
@@ -85,11 +85,12 @@ defmodule ZenEx.HelpCenter.Model.Section do
       :ok
 
   """
-  @spec destroy(integer) :: :ok | :error
+  @spec destroy(integer) :: :ok | {:error, any()}
   def destroy(id) when is_integer(id) do
-    case HTTPClient.delete("/api/v2/help_center/sections/#{id}.json").status do
-      204 -> :ok
-      _ -> :error
+    HTTPClient.delete("/api/v2/help_center/sections/#{id}.json")
+    |> case do
+      {:ok, _} -> :ok
+      {:error, response} -> {:error, response}
     end
   end
 end

--- a/lib/zen_ex/help_center/models/translation.ex
+++ b/lib/zen_ex/help_center/models/translation.ex
@@ -13,10 +13,10 @@ defmodule ZenEx.HelpCenter.Model.Translation do
   ## Examples
 
       iex> ZenEx.HelpCenter.Model.Translation.list(article_id: 1)
-      %ZenEx.Collection{}
+      {:ok, %ZenEx.Collection{}}
 
   """
-  @spec list(keyword()) :: %ZenEx.Collection{}
+  @spec list(keyword()) :: {:ok, %ZenEx.Collection{}} | {:error, any()}
   def list(_, opts \\ [])
 
   def list([category_id: category_id], opts) when is_list(opts) do
@@ -40,28 +40,42 @@ defmodule ZenEx.HelpCenter.Model.Translation do
   ## Examples
 
       iex> ZenEx.HelpCenter.Model.Translation.list_missing(article_id: 1)
-      ["en-us", "da-dk"]
+      {:ok, ["en-us", "da-dk"]}
 
   """
-  @spec list_missing(category_id: integer) :: list(String.t())
+  @spec list_missing(category_id: integer) :: {:ok, list(String.t())} | {:error, any()}
   def list_missing(category_id: category_id) do
-    HTTPClient.get("/api/v2/help_center/categories/#{category_id}/translations/missing.json").body
-    |> Poison.decode!(keys: :atoms)
-    |> Map.get(:locales)
+    with {:ok, %{body: body}} <-
+           HTTPClient.get(
+             "/api/v2/help_center/categories/#{category_id}/translations/missing.json"
+           ),
+         {:ok, decoded_body} <- Poison.decode(body, keys: :atoms) do
+      Map.fetch(decoded_body, :locales)
+    else
+      {:error, err} -> {:error, err}
+    end
   end
 
-  @spec list_missing(section_id: integer) :: list(String.t())
+  @spec list_missing(section_id: integer) :: {:ok, list(String.t())} | {:error, any()}
   def list_missing(section_id: section_id) do
-    HTTPClient.get("/api/v2/help_center/sections/#{section_id}/translations/missing.json").body
-    |> Poison.decode!(keys: :atoms)
-    |> Map.get(:locales)
+    with {:ok, %{body: body}} <-
+           HTTPClient.get("/api/v2/help_center/sections/#{section_id}/translations/missing.json"),
+         {:ok, decoded_body} <- Poison.decode(body, keys: :atoms) do
+      Map.fetch(decoded_body, :locales)
+    else
+      {:error, err} -> {:error, err}
+    end
   end
 
-  @spec list_missing(article_id: integer) :: list(String.t())
+  @spec list_missing(article_id: integer) :: {:ok, list(String.t())} | {:error, any()}
   def list_missing(article_id: article_id) do
-    HTTPClient.get("/api/v2/help_center/articles/#{article_id}/translations/missing.json").body
-    |> Poison.decode!(keys: :atoms)
-    |> Map.get(:locales)
+    with {:ok, %{body: body}} <-
+           HTTPClient.get("/api/v2/help_center/articles/#{article_id}/translations/missing.json"),
+         {:ok, decoded_body} <- Poison.decode(body, keys: :atoms) do
+      Map.fetch(decoded_body, :locales)
+    else
+      {:error, err} -> {:error, err}
+    end
   end
 
   @doc """
@@ -70,10 +84,10 @@ defmodule ZenEx.HelpCenter.Model.Translation do
   ## Examples
 
       iex> ZenEx.HelpCenter.Model.Translation.show("en-us", 1)
-      %ZenEx.HelpCenter.Entity.Translation{id: 1, title: xxx, locale: "en-us", ...}
+      {:ok, %ZenEx.HelpCenter.Entity.Translation{id: 1, title: xxx, locale: "en-us", ...}}
 
   """
-  @spec show(String.t(), integer) :: %Translation{}
+  @spec show(String.t(), integer) :: {:ok, %Translation{}} | {:error, any()}
   def show(locale, article_id) when is_integer(article_id) do
     HTTPClient.get("/api/v2/help_center/articles/#{article_id}/translations/#{locale}.json",
       translation: Translation
@@ -86,10 +100,10 @@ defmodule ZenEx.HelpCenter.Model.Translation do
   ## Examples
 
       iex> ZenEx.HelpCenter.Model.Translation.create([article_id: 1], %ZenEx.HelpCenter.Entity.Translation{title: xxx, locale: xxx, ...})
-      %ZenEx.HelpCenter.Entity.Translation{title: xxx, locale: xxx, ...}
+      {:ok, %ZenEx.HelpCenter.Entity.Translation{title: xxx, locale: xxx, ...}}
 
   """
-  @spec create([category_id: integer], %Translation{}) :: %Translation{}
+  @spec create([category_id: integer], %Translation{}) :: {:ok, %Translation{}} | {:error, any()}
   def create([category_id: category_id], %Translation{} = translation) do
     HTTPClient.post(
       "/api/v2/help_center/categories/#{category_id}/translations.json",
@@ -98,7 +112,7 @@ defmodule ZenEx.HelpCenter.Model.Translation do
     )
   end
 
-  @spec create([section_id: integer], %Translation{}) :: %Translation{}
+  @spec create([section_id: integer], %Translation{}) :: {:ok, %Translation{}} | {:error, any()}
   def create([section_id: section_id], %Translation{} = translation) do
     HTTPClient.post(
       "/api/v2/help_center/sections/#{section_id}/translations.json",
@@ -107,7 +121,7 @@ defmodule ZenEx.HelpCenter.Model.Translation do
     )
   end
 
-  @spec create([article_id: integer], %Translation{}) :: %Translation{}
+  @spec create([article_id: integer], %Translation{}) :: {:ok, %Translation{}} | {:error, any()}
   def create([article_id: article_id], %Translation{} = translation) do
     HTTPClient.post(
       "/api/v2/help_center/articles/#{article_id}/translations.json",
@@ -122,10 +136,10 @@ defmodule ZenEx.HelpCenter.Model.Translation do
   ## Examples
 
       iex> ZenEx.HelpCenter.Model.Translation.update([article_id: 1], %ZenEx.HelpCenter.Entity.Translation{id: 1, title: xxx, locale: xxx, ...})
-      %ZenEx.HelpCenter.Entity.Translation{id: 1, title: xxx, locale: xxx, ...}
+      {:ok, %ZenEx.HelpCenter.Entity.Translation{id: 1, title: xxx, locale: xxx, ...}}
 
   """
-  @spec update([category_id: integer], %Translation{}) :: %Translation{}
+  @spec update([category_id: integer], %Translation{}) :: {:ok, %Translation{}} | {:error, any()}
   def update([category_id: category_id], %Translation{} = translation) do
     HTTPClient.put(
       "/api/v2/help_center/categories/#{category_id}/translations/#{translation.locale}.json",
@@ -134,7 +148,7 @@ defmodule ZenEx.HelpCenter.Model.Translation do
     )
   end
 
-  @spec update([section_id: integer], %Translation{}) :: %Translation{}
+  @spec update([section_id: integer], %Translation{}) :: {:ok, %Translation{}} | {:error, any()}
   def update([section_id: section_id], %Translation{} = translation) do
     HTTPClient.put(
       "/api/v2/help_center/sections/#{section_id}/translations/#{translation.locale}.json",
@@ -143,7 +157,7 @@ defmodule ZenEx.HelpCenter.Model.Translation do
     )
   end
 
-  @spec update([article_id: integer], %Translation{}) :: %Translation{}
+  @spec update([article_id: integer], %Translation{}) :: {:ok, %Translation{}} | {:error, any()}
   def update([article_id: article_id], %Translation{} = translation) do
     HTTPClient.put(
       "/api/v2/help_center/articles/#{article_id}/translations/#{translation.locale}.json",
@@ -161,11 +175,12 @@ defmodule ZenEx.HelpCenter.Model.Translation do
       :ok
 
   """
-  @spec destroy(integer) :: :ok | :error
+  @spec destroy(integer) :: :ok | {:error, any()}
   def destroy(id) when is_integer(id) do
-    case HTTPClient.delete("/api/v2/help_center/translations/#{id}.json").status do
-      204 -> :ok
-      _ -> :error
+    HTTPClient.delete("/api/v2/help_center/translations/#{id}.json")
+    |> case do
+      {:ok, _} -> :ok
+      {:error, response} -> {:error, response}
     end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule ZenEx.Mixfile do
   def project do
     [
       app: :zen_ex,
-      version: "0.7.0",
+      version: "0.8.0",
       elixir: "~> 1.7",
       description: @description,
       package: package(),

--- a/spec/zen_ex/core/models/dynamic_content_spec.exs
+++ b/spec/zen_ex/core/models/dynamic_content_spec.exs
@@ -43,66 +43,107 @@ defmodule ZenEx.Model.DynamicContentSpec do
     })
   end
 
+  let(:json_error, do: ~s({"error":"RecordNotFound","description":"Not found"}))
+
   describe "list" do
     before(
       do:
         mock(fn %{method: :get, url: _} ->
-          %Tesla.Env{status: 200, body: json_dynamic_contents()}
+          {:ok, %Tesla.Env{status: 200, body: json_dynamic_contents()}}
         end)
     )
 
-    it(do: expect(Model.DynamicContent.list() |> to(be_struct(ZenEx.Collection))))
-    it(do: expect(Model.DynamicContent.list().entities |> to(eq(dynamic_contents()))))
+    it(do: expect({:ok, %ZenEx.Collection{}} = Model.DynamicContent.list()))
   end
 
   describe "show" do
-    before(
-      do:
-        mock(fn %{method: :get, url: _} ->
-          %Tesla.Env{status: 200, body: json_dynamic_content()}
-        end)
-    )
+    context "response status: 200" do
+      before(
+        do:
+          mock(fn %{method: :get, url: _} ->
+            {:ok, %Tesla.Env{status: 200, body: json_dynamic_content()}}
+          end)
+      )
 
-    it(do: expect(Model.DynamicContent.show(dynamic_content().id) |> to(eq(dynamic_content()))))
+      it(do: expect({:ok, %DynamicContent{}} = Model.DynamicContent.show(dynamic_content().id)))
+    end
+
+    context "response status: 404" do
+      before(
+        do:
+          mock(fn %{method: :get, url: _} ->
+            {:error, %Tesla.Env{status: 404, body: json_error()}}
+          end)
+      )
+
+      it(do: expect({:error, _} = Model.DynamicContent.show(dynamic_content().id)))
+    end
   end
 
   describe "create" do
-    before(
-      do:
-        mock(fn %{method: :post, url: _} ->
-          %Tesla.Env{status: 200, body: json_dynamic_content()}
-        end)
-    )
+    context "response status: 201" do
+      before(
+        do:
+          mock(fn %{method: :post, url: _} ->
+            {:ok, %Tesla.Env{status: 201, body: json_dynamic_content()}}
+          end)
+      )
 
-    it(
-      do: expect(Model.DynamicContent.create(dynamic_content()) |> to(be_struct(DynamicContent)))
-    )
+      it(do: expect({:ok, %DynamicContent{}} = Model.DynamicContent.create(dynamic_content())))
+    end
+
+    context "response status: 500" do
+      before(
+        do:
+          mock(fn %{method: :post, url: _} ->
+            {:error, %Tesla.Env{status: 500, body: ""}}
+          end)
+      )
+
+      it(do: expect({:error, _} = Model.DynamicContent.create(dynamic_content())))
+    end
   end
 
   describe "update" do
-    before(
-      do:
-        mock(fn %{method: :put, url: _} ->
-          %Tesla.Env{status: 200, body: json_dynamic_content()}
-        end)
-    )
+    context "response status: 200" do
+      before(
+        do:
+          mock(fn %{method: :put, url: _} ->
+            {:ok, %Tesla.Env{status: 200, body: json_dynamic_content()}}
+          end)
+      )
 
-    it(
-      do: expect(Model.DynamicContent.update(dynamic_content()) |> to(be_struct(DynamicContent)))
-    )
+      it(do: expect({:ok, %DynamicContent{}} = Model.DynamicContent.update(dynamic_content())))
+    end
+
+    context "response status: 500" do
+      before(
+        do:
+          mock(fn %{method: :put, url: _} ->
+            {:error, %Tesla.Env{status: 500, body: ""}}
+          end)
+      )
+
+      it(do: expect({:error, _} = Model.DynamicContent.update(dynamic_content())))
+    end
   end
 
   describe "destroy" do
     context "response status: 204" do
-      before(do: mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 204} end))
+      before(do: mock(fn %{method: :delete, url: _} -> {:ok, %Tesla.Env{status: 204}} end))
 
-      it(do: expect(Model.DynamicContent.destroy(dynamic_content().id) |> to(eq(:ok))))
+      it(do: expect(:ok = Model.DynamicContent.destroy(dynamic_content().id)))
     end
 
     context "response status: 404" do
-      before(do: mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 404} end))
+      before(
+        do:
+          mock(fn %{method: :delete, url: _} ->
+            {:error, %Tesla.Env{status: 404, body: json_error()}}
+          end)
+      )
 
-      it(do: expect(Model.DynamicContent.destroy(dynamic_content().id) |> to(eq(:error))))
+      it(do: expect({:error, _} = Model.DynamicContent.destroy(dynamic_content().id)))
     end
   end
 

--- a/spec/zen_ex/core/models/locale_spec.exs
+++ b/spec/zen_ex/core/models/locale_spec.exs
@@ -10,9 +10,10 @@ defmodule ZenEx.Model.LocaleSpec do
 
   describe "show" do
     before(
-      do: mock(fn %{method: :get, url: _} -> %Tesla.Env{status: 200, body: json_locale()} end)
+      do:
+        mock(fn %{method: :get, url: _} -> {:ok, %Tesla.Env{status: 200, body: json_locale()}} end)
     )
 
-    it(do: expect(Model.Locale.show(locale().id) |> to(eq(locale()))))
+    it(do: expect({:ok, %Locale{}} = Model.Locale.show(locale().id)))
   end
 end

--- a/spec/zen_ex/help_center/models/article_spec.exs
+++ b/spec/zen_ex/help_center/models/article_spec.exs
@@ -49,72 +49,122 @@ defmodule ZenEx.HelpCenter.Model.ArticleSpec do
     ~s({"results":[{"id":35436,"name":"Help I need somebody!","locale":"en-us","section_id":112233},{"id":20057623,"name":"Not just anybody!","locale":"en-us","section_id":112233}]})
   end
 
+  let(:json_error, do: ~s({"error":"RecordNotFound","description":"Not found"}))
+
   describe "list" do
     before(
-      do: mock(fn %{method: :get, url: _} -> %Tesla.Env{status: 200, body: json_articles()} end)
+      do:
+        mock(fn %{method: :get, url: _} ->
+          {:ok, %Tesla.Env{status: 200, body: json_articles()}}
+        end)
     )
 
-    it(do: expect(Model.Article.list("en-us") |> to(be_struct(ZenEx.Collection))))
-    it(do: expect(Model.Article.list("en-us").entities |> to(eq(articles()))))
-    it(do: expect(Model.Article.list("en-us", section().id).entities |> to(eq(articles()))))
+    it(do: expect({:ok, %ZenEx.Collection{}} = Model.Article.list("en-us")))
   end
 
   describe "show" do
-    before(
-      do: mock(fn %{method: :get, url: _} -> %Tesla.Env{status: 200, body: json_article()} end)
-    )
+    context "response status: 200" do
+      before(
+        do:
+          mock(fn %{method: :get, url: _} ->
+            {:ok, %Tesla.Env{status: 200, body: json_article()}}
+          end)
+      )
 
-    it(do: expect(Model.Article.show("en-us", article().id) |> to(eq(article()))))
+      it(do: expect({:ok, %Article{}} = Model.Article.show("en-us", article().id)))
+    end
+
+    context "response status: 404" do
+      before(
+        do:
+          mock(fn %{method: :get, url: _} ->
+            {:error, %Tesla.Env{status: 404, body: json_error()}}
+          end)
+      )
+
+      it(do: expect({:error, _} = Model.Article.show("en-us", article().id)))
+    end
   end
 
   describe "create" do
-    before(
-      do: mock(fn %{method: :post, url: _} -> %Tesla.Env{status: 200, body: json_article()} end)
-    )
+    context "response status: 201" do
+      before(
+        do:
+          mock(fn %{method: :post, url: _} ->
+            {:ok, %Tesla.Env{status: 201, body: json_article()}}
+          end)
+      )
 
-    it(do: expect(Model.Article.create(article()) |> to(be_struct(Article))))
+      it(do: expect({:ok, %Article{}} = Model.Article.create(article())))
+    end
+
+    context "response status: 500" do
+      before(
+        do:
+          mock(fn %{method: :post, url: _} ->
+            {:error, %Tesla.Env{status: 500, body: ""}}
+          end)
+      )
+
+      it(do: expect({:error, _} = Model.Article.create(article())))
+    end
   end
 
   describe "update" do
-    before(
-      do: mock(fn %{method: :put, url: _} -> %Tesla.Env{status: 200, body: json_article()} end)
-    )
+    context "response status: 200" do
+      before(
+        do:
+          mock(fn %{method: :put, url: _} ->
+            {:ok, %Tesla.Env{status: 200, body: json_article()}}
+          end)
+      )
 
-    it(do: expect(Model.Article.update(article()) |> to(be_struct(Article))))
+      it(do: expect({:ok, %Article{}} = Model.Article.update(article())))
+    end
+
+    context "response status: 500" do
+      before(
+        do:
+          mock(fn %{method: :put, url: _} ->
+            {:error, %Tesla.Env{status: 500, body: ""}}
+          end)
+      )
+
+      it(do: expect({:error, _} = Model.Article.update(article())))
+    end
   end
 
   describe "destroy" do
     context "response status: 204" do
-      before(do: mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 204} end))
+      before(do: mock(fn %{method: :delete, url: _} -> {:ok, %Tesla.Env{status: 204}} end))
 
-      it(do: expect(Model.Article.destroy(article().id) |> to(eq(:ok))))
+      it(do: expect(:ok = Model.Article.destroy(article().id)))
     end
 
     context "response status: 404" do
-      before(do: mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 404} end))
+      before(
+        do:
+          mock(fn %{method: :delete, url: _} ->
+            {:error, %Tesla.Env{status: 404, body: json_error()}}
+          end)
+      )
 
-      it(do: expect(Model.Article.destroy(article().id) |> to(eq(:error))))
+      it(do: expect({:error, _} = Model.Article.destroy(article().id)))
     end
   end
 
   describe "search" do
     before(
-      do: mock(fn %{method: :get, url: _} -> %Tesla.Env{status: 200, body: json_results()} end)
+      do:
+        mock(fn %{method: :get, url: _} ->
+          {:ok, %Tesla.Env{status: 200, body: json_results()}}
+        end)
     )
 
     it(
       do:
         expect(
-          Model.Article.search("query=hoge&updated_after=2017-01-1")
-          |> to(be_struct(ZenEx.Collection))
-        )
-    )
-
-    it(
-      do:
-        expect(
-          Model.Article.search("query=hoge&updated_after=2017-01-1").entities
-          |> to(eq(articles()))
+          {:ok, %ZenEx.Collection{}} = Model.Article.search("query=hoge&updated_after=2017-01-1")
         )
     )
   end

--- a/spec/zen_ex/help_center/models/category_spec.exs
+++ b/spec/zen_ex/help_center/models/category_spec.exs
@@ -24,6 +24,8 @@ defmodule ZenEx.HelpCenter.Model.CategorySpec do
     do: struct(Category, %{id: 35436, name: "My printer is on fire!", locale: "en-us"})
   )
 
+  let(:json_error, do: ~s({"error":"RecordNotFound","description":"Not found"}))
+
   describe "list" do
     before(
       do:
@@ -32,45 +34,97 @@ defmodule ZenEx.HelpCenter.Model.CategorySpec do
         end)
     )
 
-    it(do: expect(Model.Category.list("en-us") |> to(be_struct(ZenEx.Collection))))
-    it(do: expect(Model.Category.list("en-us").entities |> to(eq(categories()))))
+    it(do: expect({:ok, %ZenEx.Collection{}} = Model.Category.list("en-us")))
   end
 
   describe "show" do
-    before(
-      do: mock(fn %{method: :get, url: _} -> %Tesla.Env{status: 200, body: json_category()} end)
-    )
+    context "response status: 200" do
+      before(
+        do:
+          mock(fn %{method: :get, url: _} ->
+            {:ok, %Tesla.Env{status: 200, body: json_category()}}
+          end)
+      )
 
-    it(do: expect(Model.Category.show("en-us", category().id) |> to(eq(category()))))
+      it(do: expect({:ok, %Category{}} = Model.Category.show("en-us", category().id)))
+    end
+
+    context "response status: 404" do
+      before(
+        do:
+          mock(fn %{method: :get, url: _} ->
+            {:error, %Tesla.Env{status: 404, body: json_error()}}
+          end)
+      )
+
+      it(do: expect({:error, _} = Model.Category.show("en-us", category().id)))
+    end
   end
 
   describe "create" do
-    before(
-      do: mock(fn %{method: :post, url: _} -> %Tesla.Env{status: 200, body: json_category()} end)
-    )
+    context "response status: 201" do
+      before(
+        do:
+          mock(fn %{method: :post, url: _} ->
+            {:ok, %Tesla.Env{status: 201, body: json_category()}}
+          end)
+      )
 
-    it(do: expect(Model.Category.create(category()) |> to(be_struct(Category))))
+      it(do: expect({:ok, %Category{}} = Model.Category.create(category())))
+    end
+
+    context "response status: 500" do
+      before(
+        do:
+          mock(fn %{method: :post, url: _} ->
+            {:error, %Tesla.Env{status: 500, body: ""}}
+          end)
+      )
+
+      it(do: expect({:error, _} = Model.Category.create(category())))
+    end
   end
 
   describe "update" do
-    before(
-      do: mock(fn %{method: :put, url: _} -> %Tesla.Env{status: 200, body: json_category()} end)
-    )
+    context "response status: 200" do
+      before(
+        do:
+          mock(fn %{method: :put, url: _} ->
+            {:ok, %Tesla.Env{status: 200, body: json_category()}}
+          end)
+      )
 
-    it(do: expect(Model.Category.update(category()) |> to(be_struct(Category))))
+      it(do: expect({:ok, %Category{}} = Model.Category.update(category())))
+    end
+
+    context "response status: 500" do
+      before(
+        do:
+          mock(fn %{method: :put, url: _} ->
+            {:error, %Tesla.Env{status: 500, body: ""}}
+          end)
+      )
+
+      it(do: expect({:error, _} = Model.Category.update(category())))
+    end
   end
 
   describe "destroy" do
     context "response status: 204" do
-      before(do: mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 204} end))
+      before(do: mock(fn %{method: :delete, url: _} -> {:ok, %Tesla.Env{status: 204}} end))
 
-      it(do: expect(Model.Category.destroy(category().id) |> to(eq(:ok))))
+      it(do: expect(:ok = Model.Category.destroy(category().id)))
     end
 
     context "response status: 404" do
-      before(do: mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 404} end))
+      before(
+        do:
+          mock(fn %{method: :delete, url: _} ->
+            {:error, %Tesla.Env{status: 404, body: json_error()}}
+          end)
+      )
 
-      it(do: expect(Model.Category.destroy(category().id) |> to(eq(:error))))
+      it(do: expect({:error, _} = Model.Category.destroy(category().id)))
     end
   end
 end

--- a/spec/zen_ex/help_center/models/translation_spec.exs
+++ b/spec/zen_ex/help_center/models/translation_spec.exs
@@ -48,118 +48,152 @@ defmodule ZenEx.HelpCenter.Model.TranslationSpec do
     ~s({"locales":["en-us","ja"]})
   end
 
+  let(:json_error, do: ~s({"error":"RecordNotFound","description":"Not found"}))
+
   describe "list" do
     before(
       do:
         mock(fn %{method: :get, url: _} ->
-          %Tesla.Env{status: 200, body: json_translations()}
+          {:ok, %Tesla.Env{status: 200, body: json_translations()}}
         end)
     )
 
-    it(do: expect(Model.Translation.list(category_id: 1) |> to(be_struct(ZenEx.Collection))))
-    it(do: expect(Model.Translation.list(category_id: 1).entities |> to(eq(translations()))))
-    it(do: expect(Model.Translation.list(section_id: 1).entities |> to(eq(translations()))))
-    it(do: expect(Model.Translation.list(article_id: 1).entities |> to(eq(translations()))))
+    it(do: expect({:ok, %ZenEx.Collection{}} = Model.Translation.list(category_id: 1)))
+    it(do: expect({:ok, %ZenEx.Collection{}} = Model.Translation.list(section_id: 1)))
+    it(do: expect({:ok, %ZenEx.Collection{}} = Model.Translation.list(article_id: 1)))
   end
 
   describe "list_missing" do
     before(
-      do: mock(fn %{method: :get, url: _} -> %Tesla.Env{status: 200, body: json_locales()} end)
+      do:
+        mock(fn %{method: :get, url: _} ->
+          {:ok, %Tesla.Env{status: 200, body: json_locales()}}
+        end)
     )
 
-    it(do: expect(Model.Translation.list_missing(category_id: 1) |> to(eq(["en-us", "ja"]))))
-    it(do: expect(Model.Translation.list_missing(section_id: 1) |> to(eq(["en-us", "ja"]))))
-    it(do: expect(Model.Translation.list_missing(article_id: 1) |> to(eq(["en-us", "ja"]))))
+    it(do: expect({:ok, ["en-us", "ja"]} = Model.Translation.list_missing(category_id: 1)))
+    it(do: expect({:ok, ["en-us", "ja"]} = Model.Translation.list_missing(section_id: 1)))
+    it(do: expect({:ok, ["en-us", "ja"]} = Model.Translation.list_missing(article_id: 1)))
   end
 
   describe "show" do
-    before(
-      do:
-        mock(fn %{method: :get, url: _} ->
-          %Tesla.Env{status: 200, body: json_translation()}
-        end)
-    )
+    context "response status: 200" do
+      before(
+        do:
+          mock(fn %{method: :get, url: _} ->
+            {:ok, %Tesla.Env{status: 200, body: json_translation()}}
+          end)
+      )
 
-    it(do: expect(Model.Translation.show("en-us", 1) |> to(eq(translation()))))
+      it(do: expect({:ok, %Translation{}} = Model.Translation.show("en-us", 1)))
+    end
+
+    context "response status: 404" do
+      before(
+        do:
+          mock(fn %{method: :get, url: _} ->
+            {:error, %Tesla.Env{status: 404, body: json_error()}}
+          end)
+      )
+
+      it(do: expect({:error, _} = Model.Translation.show("en-us", 1)))
+    end
   end
 
   describe "create" do
-    before(
-      do:
-        mock(fn %{method: :post, url: _} ->
-          %Tesla.Env{status: 200, body: json_translation()}
-        end)
-    )
+    context "response status: 201" do
+      before(
+        do:
+          mock(fn %{method: :post, url: _} ->
+            {:ok, %Tesla.Env{status: 201, body: json_translation()}}
+          end)
+      )
 
-    it(
-      do:
-        expect(
-          Model.Translation.create([category_id: 1], translation())
-          |> to(be_struct(Translation))
-        )
-    )
+      it(
+        do:
+          expect(
+            {:ok, %Translation{}} = Model.Translation.create([category_id: 1], translation())
+          )
+      )
 
-    it(
-      do:
-        expect(
-          Model.Translation.create([section_id: 1], translation())
-          |> to(be_struct(Translation))
-        )
-    )
+      it(
+        do:
+          expect({:ok, %Translation{}} = Model.Translation.create([section_id: 1], translation()))
+      )
 
-    it(
-      do:
-        expect(
-          Model.Translation.create([article_id: 1], translation())
-          |> to(be_struct(Translation))
-        )
-    )
+      it(
+        do:
+          expect({:ok, %Translation{}} = Model.Translation.create([article_id: 1], translation()))
+      )
+    end
+
+    context "response status: 500" do
+      before(
+        do:
+          mock(fn %{method: :post, url: _} ->
+            {:error, %Tesla.Env{status: 500, body: ""}}
+          end)
+      )
+
+      it(do: expect({:error, _} = Model.Translation.create([category_id: 1], translation())))
+    end
   end
 
   describe "update" do
-    before(
-      do:
-        mock(fn %{method: :put, url: _} ->
-          %Tesla.Env{status: 200, body: json_translation()}
-        end)
-    )
+    context "response status: 200" do
+      before(
+        do:
+          mock(fn %{method: :put, url: _} ->
+            {:ok, %Tesla.Env{status: 200, body: json_translation()}}
+          end)
+      )
 
-    it(
-      do:
-        expect(
-          Model.Translation.update([category_id: 1], translation())
-          |> to(be_struct(Translation))
-        )
-    )
+      it(
+        do:
+          expect(
+            {:ok, %Translation{}} = Model.Translation.update([category_id: 1], translation())
+          )
+      )
 
-    it(
-      do:
-        expect(
-          Model.Translation.update([section_id: 1], translation())
-          |> to(be_struct(Translation))
-        )
-    )
+      it(
+        do:
+          expect({:ok, %Translation{}} = Model.Translation.update([section_id: 1], translation()))
+      )
 
-    it(
-      do:
-        expect(
-          Model.Translation.update([article_id: 1], translation())
-          |> to(be_struct(Translation))
-        )
-    )
+      it(
+        do:
+          expect({:ok, %Translation{}} = Model.Translation.update([article_id: 1], translation()))
+      )
+    end
+
+    context "response status: 500" do
+      before(
+        do:
+          mock(fn %{method: :put, url: _} ->
+            {:error, %Tesla.Env{status: 500, body: ""}}
+          end)
+      )
+
+      it(do: expect({:error, _} = Model.Translation.update([category_id: 1], translation())))
+    end
   end
 
   describe "destroy" do
     context "response status: 204" do
-      before(do: mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 204} end))
+      before(do: mock(fn %{method: :delete, url: _} -> {:ok, %Tesla.Env{status: 204}} end))
 
-      it(do: expect(Model.Translation.destroy(translation().id) |> to(eq(:ok))))
+      it(do: expect(:ok = Model.Translation.destroy(translation().id)))
     end
 
     context "response status: 404" do
-      before(do: mock(fn %{method: :delete, url: _} -> %Tesla.Env{status: 404} end))
+      before(
+        do:
+          mock(fn %{method: :delete, url: _} ->
+            {:error, %Tesla.Env{status: 404, body: json_error()}}
+          end)
+      )
 
-      it(do: expect(Model.Translation.destroy(translation().id) |> to(eq(:error))))
+      it(do: expect({:error, _} = Model.Translation.destroy(translation().id)))
     end
   end
 end


### PR DESCRIPTION
Fixed https://github.com/otoyo/zen_ex/issues/13, fixed https://github.com/otoyo/zen_ex/issues/27, fixed https://github.com/otoyo/zen_ex/issues/28

`ZenEx.HTTPClient` client now returns `{:ok, _}` or `{:error, _}`.