### PR TITLE
Add user tags and handle external id in search

### DIFF
--- a/lib/zen_ex/core/models/user.ex
+++ b/lib/zen_ex/core/models/user.ex
@@ -186,7 +186,14 @@ defmodule ZenEx.Model.User do
 
   @spec search(String.t()) :: {:ok, %ZenEx.Collection{}} | {:error, any()}
   def search(query) do
-    "/api/v2/users/search.json?query=#{query}"
+    base_url = "/api/v2/users/search.json?"
+
+    # external_id queries are special case where we expect an exact match
+    # no other query criteria should be present
+    cond do
+      String.starts_with?(query, "external_id") -> "#{base_url}external_id=#{query |> String.split(":") |> List.last()}"
+      true -> "#{base_url}query=#{query}"
+    end
     |> HTTPClient.get(users: [User])
   end
 end

--- a/lib/zen_ex/core/models/user.ex
+++ b/lib/zen_ex/core/models/user.ex
@@ -196,4 +196,26 @@ defmodule ZenEx.Model.User do
     end
     |> HTTPClient.get(users: [User])
   end
+
+  @doc """
+  Add tags for a user.
+
+  Only additive. Won't overwrite existing tags.
+
+  ## Examples
+
+      iex> ZenEx.Model.User.add_tags(id, ["tag 1", "tag 2"])
+      {:ok, %{tags: ["tag 1", "tag 2"]}}
+
+  """
+  @spec add_tags(%User{}, list(String.t())) :: {:ok, map()} | {:error, any()}
+  def add_tags(user, tags) do
+    response = HTTPClient.put("/api/v2/users/#{user.id}/tags.json",
+      %{"tags" => tags, "safe_update" => true, "updated_stamp" => user.updated_at})
+
+    case response do
+      {:ok, %{body: body}} -> Poison.decode!(body, keys: :atoms)
+      {:error, error} -> {:error, error}
+    end
+  end
 end

--- a/lib/zen_ex/core/models/user.ex
+++ b/lib/zen_ex/core/models/user.ex
@@ -214,7 +214,7 @@ defmodule ZenEx.Model.User do
       %{"tags" => tags, "safe_update" => true, "updated_stamp" => user.updated_at})
 
     case response do
-      {:ok, %{body: body}} -> Poison.decode!(body, keys: :atoms)
+      {:ok, %{body: body}} -> Poison.decode(body, keys: :atoms) 
       {:error, error} -> {:error, error}
     end
   end

--- a/spec/zen_ex/core/models/user_spec.exs
+++ b/spec/zen_ex/core/models/user_spec.exs
@@ -32,6 +32,10 @@ defmodule ZenEx.Model.UserSpec do
     ~s({"count":2,"users":[{"id":223443,"name":"Johnny Agent"},{"id":8678530,"name":"James A. Rosen"}]})
   end
 
+  let :json_search_external_id_users do
+    ~s({"count":1,"users":[{"id":223443,"name":"Johnny Agent","external_id":1234567}]})
+  end
+
   let(:json_error, do: ~s({"error":"RecordNotFound","description":"Not found"}))
 
   describe "list" do
@@ -307,6 +311,24 @@ defmodule ZenEx.Model.UserSpec do
 
       context "when argument is a string" do
         it(do: expect({:ok, %ZenEx.Collection{}} = Model.User.search("my_string")))
+      end
+    end
+
+    context "response status: 200 and external_id" do
+      before(
+        do:
+          mock(fn %{method: :get, url: _} ->
+            {:ok, %Tesla.Env{status: 200, body: json_search_external_id_users()}}
+          end)
+      )
+
+      context "when argument is a map" do
+        it(
+          do:
+            expect(
+              {:ok, %ZenEx.Collection{count: 1, entities: [%{external_id: 1234567}]}} = Model.User.search(%{external_id: 1234567})
+            )
+        )
       end
     end
   end

--- a/spec/zen_ex/core/models/user_spec.exs
+++ b/spec/zen_ex/core/models/user_spec.exs
@@ -36,6 +36,8 @@ defmodule ZenEx.Model.UserSpec do
     ~s({"count":1,"users":[{"id":223443,"name":"Johnny Agent","external_id":1234567}]})
   end
 
+  let(:json_tags, do: ~s({"tags":["tag 1","tag 2"]}))
+  
   let(:json_error, do: ~s({"error":"RecordNotFound","description":"Not found"}))
 
   describe "list" do
@@ -330,6 +332,25 @@ defmodule ZenEx.Model.UserSpec do
             )
         )
       end
+    end
+  end
+
+  describe "add_tags" do
+    context "response status: 200" do
+      before(
+        do:
+          mock(fn %{method: :put, url: _} -> {:ok, %Tesla.Env{status: 200, body: json_tags()}} end)
+      )
+
+      it(do: expect({:ok, %{tags: ["tag 1", "tag 2"]}} = Model.User.add_tags(user(), ["tag 1", "tag 2"])))
+    end
+
+    context "response status: 500" do
+      before(
+        do: mock(fn %{method: :put, url: _} -> {:error, %Tesla.Env{status: 500, body: ""}} end)
+      )
+
+      it(do: expect({:error, _} = Model.User.add_tags(user(), nil)))
     end
   end
 end


### PR DESCRIPTION
This extends user model search to handle `external_id` special case as outlined in [API docs](https://developer.zendesk.com/api-reference/ticketing/users/users/#search-users).

It also adds the ability for user model to add tags to the user as outlined in [API docs](https://developer.zendesk.com/api-reference/ticketing/ticket-management/tags/#add-tags).